### PR TITLE
Add rank-N Tensor type with flat storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,11 @@ Tests/SwiftMatrixTests/  -- tests
 - All public API types and members must be explicitly marked `public`
 - Tests use Swift Testing framework (`import Testing`, `@Test`, `#expect`)
 - Prefer value types (structs)
+
+## Architecture
+
+`Tensor<Element>` uses flat `[Element]` storage with `shape: [Int]`, `strides: [Int]`, and `offset: Int`. Row-major (C-order) strides by default. The `offset` field enables zero-copy views for future slice/transpose operations.
+
+Collection conformance uses `Index = Int` (linear index) for `RandomAccessCollection`. Multi-dimensional access via `subscript(_ indices: Int...)`.
+
+Conditional conformances: `Equatable`, `Hashable`, `Sendable` (when `Element` conforms).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,30 @@ swift build
 swift test
 ```
 
-## Current Types
+## Types
+
+### Tensor
+
+`Tensor<Element>` is a rank-N multi-dimensional array backed by flat `[Element]` storage with shape/strides. Row-major (C-order) layout by default.
+
+```swift
+// Create from shape + repeating value
+let zeros = Tensor(shape: [2, 3, 4], repeating: 0.0)
+
+// Create from flat array + shape
+let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+
+// Create from nested arrays (rank 2)
+let m = Tensor([[1, 2, 3], [4, 5, 6]])
+
+// Multi-dimensional subscript
+t[1, 2]  // 6
+
+// Conforms to RandomAccessCollection (linear index)
+Array(t)  // [1, 2, 3, 4, 5, 6]
+```
+
+### Legacy Types
 
 - `Matrix<E>` -- rank-2 collection backed by nested arrays, indexed by `Pair`
 - `Pair` -- 2D index with `x` and `y` components
@@ -20,6 +43,6 @@ swift test
 
 ## Roadmap
 
-- Flat-storage rank-N `Tensor` type with shape/strides
 - Zero-copy transpose, slice, and reshape via stride manipulation
 - Element-wise arithmetic
+- Compatibility layer bridging `Matrix`/`Vector`/`Pair` to `Tensor`

--- a/Sources/SwiftMatrix/Tensor+Collection.swift
+++ b/Sources/SwiftMatrix/Tensor+Collection.swift
@@ -1,0 +1,32 @@
+extension Tensor: RandomAccessCollection {
+    public var startIndex: Int { 0 }
+    public var endIndex: Int { shape.reduce(1, *) }
+
+    public subscript(linearIndex linearIndex: Int) -> Element {
+        get { storage[storageIndex(forLinearIndex: linearIndex)] }
+        set { storage[storageIndex(forLinearIndex: linearIndex)] = newValue }
+    }
+
+    public subscript(position: Int) -> Element {
+        get { storage[storageIndex(forLinearIndex: position)] }
+        set { storage[storageIndex(forLinearIndex: position)] = newValue }
+    }
+
+    public func index(after i: Int) -> Int { i + 1 }
+    public func index(before i: Int) -> Int { i - 1 }
+}
+
+extension Tensor: Equatable where Element: Equatable {
+    public static func == (lhs: Tensor, rhs: Tensor) -> Bool {
+        lhs.shape == rhs.shape && Array(lhs) == Array(rhs)
+    }
+}
+
+extension Tensor: Hashable where Element: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(shape)
+        for element in self {
+            hasher.combine(element)
+        }
+    }
+}

--- a/Sources/SwiftMatrix/Tensor+Subscripts.swift
+++ b/Sources/SwiftMatrix/Tensor+Subscripts.swift
@@ -1,0 +1,11 @@
+extension Tensor {
+    public subscript(indices: [Int]) -> Element {
+        get { storage[storageIndex(for: indices)] }
+        set { storage[storageIndex(for: indices)] = newValue }
+    }
+
+    public subscript(indices: Int...) -> Element {
+        get { storage[storageIndex(for: indices)] }
+        set { storage[storageIndex(for: indices)] = newValue }
+    }
+}

--- a/Sources/SwiftMatrix/Tensor.swift
+++ b/Sources/SwiftMatrix/Tensor.swift
@@ -1,0 +1,79 @@
+public struct Tensor<Element> {
+    var storage: [Element]
+    public let shape: [Int]
+    public let strides: [Int]
+    public let offset: Int
+
+    public var rank: Int { shape.count }
+
+    public init(shape: [Int], repeating repeatedValue: Element) {
+        let count = shape.reduce(1, *)
+        self.storage = Array(repeating: repeatedValue, count: count)
+        self.shape = shape
+        self.strides = Self.computeStrides(for: shape)
+        self.offset = 0
+    }
+
+    public init(shape: [Int], elements: [Element]) {
+        let count = shape.reduce(1, *)
+        precondition(elements.count == count,
+                     "Element count \(elements.count) does not match shape \(shape) (expected \(count))")
+        self.storage = elements
+        self.shape = shape
+        self.strides = Self.computeStrides(for: shape)
+        self.offset = 0
+    }
+
+    public init(_ arrays: [[Element]]) {
+        let depth = arrays.count
+        guard depth > 0 else {
+            self.init(shape: [0, 0], elements: [])
+            return
+        }
+        let width = arrays[0].count
+        precondition(arrays.allSatisfy { $0.count == width },
+                     "All rows must have the same length")
+        self.init(shape: [depth, width], elements: arrays.flatMap { $0 })
+    }
+
+    init(storage: [Element], shape: [Int], strides: [Int], offset: Int) {
+        self.storage = storage
+        self.shape = shape
+        self.strides = strides
+        self.offset = offset
+    }
+
+    static func computeStrides(for shape: [Int]) -> [Int] {
+        guard !shape.isEmpty else { return [] }
+        var strides = Array(repeating: 1, count: shape.count)
+        for i in Swift.stride(from: shape.count - 2, through: 0, by: -1) {
+            strides[i] = strides[i + 1] * shape[i + 1]
+        }
+        return strides
+    }
+
+    var isContiguous: Bool {
+        strides == Self.computeStrides(for: shape) && offset == 0
+    }
+
+    func storageIndex(for indices: [Int]) -> Int {
+        precondition(indices.count == rank,
+                     "Expected \(rank) indices, got \(indices.count)")
+        return offset + zip(indices, strides).reduce(0) { $0 + $1.0 * $1.1 }
+    }
+
+    func storageIndex(forLinearIndex linear: Int) -> Int {
+        guard !isContiguous else { return linear }
+        var remaining = linear
+        var storageIdx = offset
+        for axis in 0..<rank {
+            let logicalStride = shape[(axis + 1)...].reduce(1, *)
+            let coord = remaining / logicalStride
+            remaining %= logicalStride
+            storageIdx += coord * strides[axis]
+        }
+        return storageIdx
+    }
+}
+
+extension Tensor: Sendable where Element: Sendable {}

--- a/Tests/SwiftMatrixTests/TensorCollectionTests.swift
+++ b/Tests/SwiftMatrixTests/TensorCollectionTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import SwiftMatrix
+
+struct TensorIterationTests {
+    @Test func iterationOrderRowMajor() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        let elements = Array(t)
+        #expect(elements == [1, 2, 3, 4, 5, 6])
+    }
+
+    @Test func iterationRank3() {
+        let t = Tensor(shape: [2, 2, 2], elements: Array(1...8))
+        let elements = Array(t)
+        #expect(elements == [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    @Test func iterationRank1() {
+        let t = Tensor(shape: [4], elements: [10, 20, 30, 40])
+        let elements = Array(t)
+        #expect(elements == [10, 20, 30, 40])
+    }
+
+    @Test func linearSubscriptMatchesIteration() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        for i in 0..<t.count {
+            #expect(t[linearIndex: i] == Array(t)[i])
+        }
+    }
+
+    @Test func emptyTensorIteration() {
+        let t = Tensor(shape: [0, 3], repeating: 0)
+        #expect(Array(t).isEmpty)
+    }
+
+    @Test func collectionStartAndEndIndex() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(t.startIndex == 0)
+        #expect(t.endIndex == 6)
+    }
+
+    @Test func collectionCount() {
+        let t = Tensor(shape: [3, 4], repeating: 0)
+        #expect(t.count == 12)
+    }
+}
+
+struct TensorEquatableTests {
+    @Test func equalTensors() {
+        let a = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        let b = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(a == b)
+    }
+
+    @Test func differentElements() {
+        let a = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        let b = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 7])
+        #expect(a != b)
+    }
+
+    @Test func differentShapes() {
+        let a = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        let b = Tensor(shape: [3, 2], elements: [1, 2, 3, 4, 5, 6])
+        #expect(a != b)
+    }
+}
+
+struct TensorHashableTests {
+    @Test func equalTensorsHashEqual() {
+        let a = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        let b = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(a.hashValue == b.hashValue)
+    }
+
+    @Test func usableInSet() {
+        let a = Tensor(shape: [2], elements: [1, 2])
+        let b = Tensor(shape: [2], elements: [1, 2])
+        let c = Tensor(shape: [2], elements: [3, 4])
+        let set: Set = [a, b, c]
+        #expect(set.count == 2)
+    }
+}

--- a/Tests/SwiftMatrixTests/TensorTests.swift
+++ b/Tests/SwiftMatrixTests/TensorTests.swift
@@ -1,0 +1,119 @@
+import Testing
+@testable import SwiftMatrix
+
+struct TensorCreationTests {
+    @Test func createFromShapeAndRepeatingValue() {
+        let t = Tensor(shape: [2, 3], repeating: 0.0)
+        #expect(t.shape == [2, 3])
+        #expect(t.rank == 2)
+        #expect(t.count == 6)
+        #expect(t.strides == [3, 1])
+    }
+
+    @Test func createFromFlatArrayAndShape() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(t.shape == [2, 3])
+        #expect(t[0, 0] == 1)
+        #expect(t[0, 2] == 3)
+        #expect(t[1, 0] == 4)
+        #expect(t[1, 2] == 6)
+    }
+
+    @Test func createFromNestedArrays() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        #expect(t.shape == [2, 3])
+        #expect(t.rank == 2)
+        #expect(t[0, 0] == 1)
+        #expect(t[0, 2] == 3)
+        #expect(t[1, 0] == 4)
+        #expect(t[1, 2] == 6)
+    }
+
+    @Test func createScalar() {
+        let t = Tensor(shape: [], elements: [42])
+        #expect(t.shape == [])
+        #expect(t.rank == 0)
+        #expect(t.count == 1)
+        #expect(t.strides == [])
+    }
+
+    @Test func createRank1() {
+        let t = Tensor(shape: [4], elements: [10, 20, 30, 40])
+        #expect(t.shape == [4])
+        #expect(t.rank == 1)
+        #expect(t.count == 4)
+        #expect(t.strides == [1])
+        #expect(t[2] == 30)
+    }
+}
+
+struct TensorStridesTests {
+    @Test(arguments: [
+        (shape: [Int](),     expected: [Int]()),
+        (shape: [4],         expected: [1]),
+        (shape: [2, 3],      expected: [3, 1]),
+        (shape: [2, 3, 4],   expected: [12, 4, 1]),
+        (shape: [5, 4, 3, 2], expected: [24, 6, 2, 1]),
+    ])
+    func rowMajorStrides(shape: [Int], expected: [Int]) {
+        let t = Tensor(shape: shape, repeating: 0)
+        #expect(t.strides == expected)
+    }
+}
+
+struct TensorSubscriptTests {
+    @Test func getAndSetRank2() {
+        var t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(t[1, 1] == 5)
+        t[1, 1] = 99
+        #expect(t[1, 1] == 99)
+    }
+
+    @Test func getAndSetRank3() {
+        var t = Tensor(shape: [2, 3, 4], repeating: 0)
+        t[1, 2, 3] = 42
+        #expect(t[1, 2, 3] == 42)
+        // Verify other elements remain 0
+        #expect(t[0, 0, 0] == 0)
+        #expect(t[1, 2, 2] == 0)
+    }
+
+    @Test func getAndSetRank1() {
+        var t = Tensor(shape: [3], elements: [10, 20, 30])
+        #expect(t[1] == 20)
+        t[1] = 99
+        #expect(t[1] == 99)
+    }
+
+    @Test func arraySubscriptGet() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(t[[1, 2]] == 6)
+    }
+
+    @Test func arraySubscriptSet() {
+        var t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        t[[0, 1]] = 99
+        #expect(t[[0, 1]] == 99)
+    }
+}
+
+struct TensorEdgeCaseTests {
+    @Test func emptyDimension() {
+        let t = Tensor(shape: [0, 3], repeating: 0)
+        #expect(t.count == 0)
+        #expect(Array(t).isEmpty)
+    }
+
+    @Test func singleElement() {
+        let t = Tensor(shape: [1, 1], repeating: 42)
+        #expect(t.count == 1)
+        #expect(t[0, 0] == 42)
+    }
+
+    @Test func highRank() {
+        let t = Tensor(shape: [2, 2, 2, 2], repeating: 1)
+        #expect(t.count == 16)
+        #expect(t.rank == 4)
+        #expect(t.strides == [8, 4, 2, 1])
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Tensor<Element>` struct with flat `[Element]` storage, `shape: [Int]`, `strides: [Int]`, and `offset: Int`
- Row-major (C-order) strides computed automatically
- Three initializers: shape+repeating, flat array+shape, nested arrays
- `RandomAccessCollection` conformance with `Index = Int` (linear index)
- Multi-dimensional subscript via `subscript(_ indices: Int...)` and `subscript(_ indices: [Int])` (both get and set)
- Conditional `Equatable`, `Hashable`, and `Sendable` conformances
- Contiguity optimization for linear index access
- 26 new tests covering creation, strides, subscripts, iteration, equality, hashing, and edge cases (rank 0, 1, empty dimensions, high rank)

Closes #3

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` passes all 35 tests (9 existing + 26 new)
- [x] Tensor creation from shape+repeating, flat array+shape, nested arrays
- [x] Row-major strides for ranks 0-4
- [x] Multi-dimensional subscript get/set for ranks 1-3
- [x] RandomAccessCollection iteration in row-major order
- [x] Equatable and Hashable conformances
- [x] Edge cases: scalar, rank 1, empty dimensions, high rank