### PR TITLE
Add API documentation to all public types

### DIFF
--- a/Sources/SwiftMatrix/CollectionView.swift
+++ b/Sources/SwiftMatrix/CollectionView.swift
@@ -1,16 +1,32 @@
-//
-//  CollectionView.swift
-//  Sandbox
-//
-//  Created by Jake Bromberg on 4/22/21.
-//  Copyright © 2021 Jake Bromberg. All rights reserved.
-//
-
+/// A lazy view over a collection that remaps indices through a swizzler function.
+///
+/// `CollectionView` wraps an existing collection and intercepts subscript access, passing
+/// each index through a ``Swizzler`` before forwarding to the underlying storage. This
+/// enables operations like transpose and cyclic shift without copying data.
+///
+/// ```swift
+/// let matrix = Matrix([[1, 2], [3, 4]])
+/// let transposed = CollectionView(
+///     swizzler: { Pair(x: $0.y, y: $0.x) },
+///     storage: matrix
+/// )
+/// transposed[Pair(x: 0, y: 1)]  // matrix[Pair(x: 1, y: 0)] == 3
+/// ```
+///
+/// The view inherits `startIndex`, `endIndex`, and `index(after:)` directly from the
+/// underlying collection. Only subscript access is remapped.
 public struct CollectionView<Collection: Swift.Collection>: Swift.Collection {
+  /// A function that transforms a logical index into a storage index.
   public typealias Swizzler = (Collection.Index) -> Collection.Index
+
   let swizzler: Swizzler
   let storage: Collection
 
+  /// Creates a view that remaps index access through the given swizzler.
+  ///
+  /// - Parameters:
+  ///   - swizzler: A function mapping logical indices to physical indices in `storage`.
+  ///   - storage: The underlying collection to read elements from.
   public init(swizzler: @escaping Swizzler, storage: Collection) {
     self.swizzler = swizzler
     self.storage = storage
@@ -21,6 +37,10 @@ public struct CollectionView<Collection: Swift.Collection>: Swift.Collection {
   public typealias Index = Collection.Index
   public typealias Element = Collection.Element
 
+  /// Accesses the element at the swizzled position.
+  ///
+  /// The given `position` is passed through the ``Swizzler`` before indexing into the
+  /// underlying storage.
   public subscript(position: Collection.Index) -> Collection.Element {
     storage[swizzler(position)]
   }

--- a/Sources/SwiftMatrix/Matrix.swift
+++ b/Sources/SwiftMatrix/Matrix.swift
@@ -1,22 +1,41 @@
-//
-//  Matrix.swift
-//  Sandbox
-//
-//  Created by Jake Bromberg on 4/22/21.
-//  Copyright © 2021 Jake Bromberg. All rights reserved.
-//
-
+/// A rank-2 collection backed by nested arrays.
+///
+/// `Matrix` stores elements as `[[E]]` and conforms to `Collection` with ``Pair`` as its
+/// index type. Elements are iterated in row-major order: all columns of row 0, then row 1,
+/// and so on.
+///
+/// ```swift
+/// let m = Matrix([[1, 2, 3],
+///                 [4, 5, 6]])
+/// m[Pair(x: 0, y: 2)]  // 3
+/// Array(m)              // [1, 2, 3, 4, 5, 6]
+/// ```
+///
+/// For new code, prefer ``Tensor`` which supports arbitrary rank and uses flat storage
+/// with shape/strides for efficient zero-copy operations.
 public struct Matrix<E> {
   fileprivate let storage: [[E]]
 
+  /// The dimensions of this matrix.
   public let size: Vector
 
+  /// Creates a matrix filled with a repeated value.
+  ///
+  /// - Parameters:
+  ///   - size: The dimensions of the matrix (`width` columns, `depth` rows).
+  ///   - repeatedValue: The value to fill every element with.
   public init(size: Vector, repeating repeatedValue: E) {
     let row: [E] = Array(repeating: repeatedValue, count: size.width)
     self.storage = Array(repeating: row, count: size.depth)
     self.size = size
   }
 
+  /// Creates a matrix from nested arrays.
+  ///
+  /// The outer array represents rows and each inner array represents columns.
+  /// All inner arrays must have the same length.
+  ///
+  /// - Parameter arrays: The rows of the matrix. All rows must have equal length.
   public init(_ arrays: [[E]]) {
     let widths = Set(arrays.map(\.count))
 
@@ -28,6 +47,8 @@ public struct Matrix<E> {
     self.size = Vector(width: widths.first!, depth: arrays.count)
   }
 }
+
+// MARK: - Collection
 
 extension Matrix: Collection {
   public func index(after i: Pair) -> Pair {
@@ -42,6 +63,9 @@ extension Matrix: Collection {
     return Pair(x: i.x, y: i.y + 1)
   }
 
+  /// Accesses the element at the given row/column position.
+  ///
+  /// - Parameter position: A ``Pair`` where `x` is the row and `y` is the column.
   public subscript(position: Pair) -> E {
     self.storage[position.x][position.y]
   }
@@ -66,7 +90,15 @@ extension Matrix: Hashable where Element: Hashable {
 
 }
 
+// MARK: - Views
+
 extension Matrix {
+  /// Returns a view that transposes row and column access.
+  ///
+  /// The returned ``CollectionView`` swaps the `x` and `y` components of each index,
+  /// so reading `inverted[Pair(x: r, y: c)]` returns `self[Pair(x: c, y: r)]`.
+  ///
+  /// - Returns: A transposed view over this matrix.
   public func invert() -> CollectionView<Matrix> {
     let swizzler = { (index: Pair) in
       Pair(x: index.y, y: index.x)
@@ -77,6 +109,13 @@ extension Matrix {
     return result
   }
 
+  /// Returns a view with indices shifted by the given offset, wrapping around the matrix.
+  ///
+  /// Each index `(x, y)` is mapped to `((x + pair.x) % size.width, (y + pair.y) % size.depth)`,
+  /// creating a toroidal (wrap-around) shift of the matrix contents.
+  ///
+  /// - Parameter pair: The amount to shift indices by along each axis.
+  /// - Returns: A cyclically shifted view over this matrix.
   public func offset(by pair: Pair) -> CollectionView<Matrix> {
     let swizzler = { (index: Pair) in
       (index + pair) % size

--- a/Sources/SwiftMatrix/Pair.swift
+++ b/Sources/SwiftMatrix/Pair.swift
@@ -1,17 +1,25 @@
-//
-//  Pair.swift
-//  Sandbox
-//
-//  Created by Jake Bromberg on 4/22/21.
-//  Copyright © 2021 Jake Bromberg. All rights reserved.
-//
-
+/// A two-component integer index used by ``Matrix`` for row/column addressing.
+///
+/// `Pair` serves as the `Collection.Index` type for ``Matrix``. The `x` component addresses
+/// rows and `y` addresses columns.
+///
+/// ```swift
+/// let p = Pair(x: 1, y: 2)
+/// matrix[p]  // element at row 1, column 2
+/// ```
+///
+/// `Pair` conforms to `Comparable` using a component-wise partial order (both `x` and `y`
+/// must be less). This is sufficient for ``Matrix``'s `Collection` conformance but does not
+/// define a total order over all pairs.
 public struct Pair: Comparable {
   public static func < (lhs: Pair, rhs: Pair) -> Bool {
     lhs.x < rhs.x && lhs.y < rhs.y
   }
 
+  /// The row index.
   public let x: Int
+
+  /// The column index.
   public let y: Int
 
   public init(x: Int, y: Int) {
@@ -19,10 +27,15 @@ public struct Pair: Comparable {
     self.y = y
   }
 
+  /// Returns the component-wise sum of two pairs.
   public static func +(lhs: Pair, rhs: Pair) -> Pair {
     Pair(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
   }
 
+  /// Returns the component-wise remainder of a pair divided by a vector's dimensions.
+  ///
+  /// Wraps `x` by ``Vector/width`` and `y` by ``Vector/depth``. Used by
+  /// ``Matrix/offset(by:)`` for toroidal index wrapping.
   public static func %(lhs: Pair, rhs: Vector) -> Pair {
     Pair(x: lhs.x % rhs.width, y: lhs.y % rhs.depth)
   }

--- a/Sources/SwiftMatrix/Tensor+Collection.swift
+++ b/Sources/SwiftMatrix/Tensor+Collection.swift
@@ -1,12 +1,30 @@
+/// `RandomAccessCollection` conformance using a flat linear index.
+///
+/// The collection index is `Int`, representing a position in row-major iteration order.
+/// This avoids the partial-order problem that ``Pair`` has with `Comparable` and enables
+/// efficient random access.
 extension Tensor: RandomAccessCollection {
     public var startIndex: Int { 0 }
     public var endIndex: Int { shape.reduce(1, *) }
 
+    /// Accesses the element at the given linear index using an explicit argument label.
+    ///
+    /// This subscript disambiguates from the multi-dimensional ``subscript(_:)-6gkqj``
+    /// when you want to explicitly use the flat linear index.
+    ///
+    /// - Parameter linearIndex: A position in `0..<count`, following row-major order.
     public subscript(linearIndex linearIndex: Int) -> Element {
         get { storage[storageIndex(forLinearIndex: linearIndex)] }
         set { storage[storageIndex(forLinearIndex: linearIndex)] = newValue }
     }
 
+    /// Accesses the element at the given linear index (`Collection` conformance).
+    ///
+    /// For a tensor with shape `[2, 3]` and elements `[1, 2, 3, 4, 5, 6]`:
+    /// - Position 0 is element `1` (at coordinates `[0, 0]`)
+    /// - Position 3 is element `4` (at coordinates `[1, 0]`)
+    ///
+    /// - Parameter position: A valid index in `startIndex..<endIndex`.
     public subscript(position: Int) -> Element {
         get { storage[storageIndex(forLinearIndex: position)] }
         set { storage[storageIndex(forLinearIndex: position)] = newValue }
@@ -16,12 +34,17 @@ extension Tensor: RandomAccessCollection {
     public func index(before i: Int) -> Int { i - 1 }
 }
 
+/// Tensors are equal when they have the same shape and the same elements in the same positions.
+///
+/// Two tensors with different internal layouts (e.g., different strides from a transpose) but
+/// the same logical shape and elements are considered equal.
 extension Tensor: Equatable where Element: Equatable {
     public static func == (lhs: Tensor, rhs: Tensor) -> Bool {
         lhs.shape == rhs.shape && Array(lhs) == Array(rhs)
     }
 }
 
+/// Hashing incorporates both shape and elements, consistent with ``Equatable``.
 extension Tensor: Hashable where Element: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(shape)

--- a/Sources/SwiftMatrix/Tensor+Subscripts.swift
+++ b/Sources/SwiftMatrix/Tensor+Subscripts.swift
@@ -1,9 +1,36 @@
+/// Multi-dimensional subscript access for ``Tensor``.
+///
+/// These subscripts convert multi-dimensional coordinates (one index per axis) into a flat
+/// storage index using the tensor's strides. Both get and set are supported; mutation through
+/// a view triggers a copy-on-write of the underlying storage array.
 extension Tensor {
+    /// Accesses the element at the given multi-dimensional coordinates.
+    ///
+    /// ```swift
+    /// let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+    /// t[[1, 2]]  // 6
+    /// ```
+    ///
+    /// - Parameter indices: An array with one index per axis.
+    /// - Precondition: `indices.count` equals ``rank``.
     public subscript(indices: [Int]) -> Element {
         get { storage[storageIndex(for: indices)] }
         set { storage[storageIndex(for: indices)] = newValue }
     }
 
+    /// Accesses the element at the given multi-dimensional coordinates.
+    ///
+    /// ```swift
+    /// let t = Tensor(shape: [2, 3, 4], repeating: 0)
+    /// t[1, 2, 3]  // element at row 1, column 2, depth 3
+    /// ```
+    ///
+    /// For rank-1 tensors, a single-argument call is ambiguous with the `Collection`
+    /// position subscript; Swift resolves it to the `Collection` subscript, which produces
+    /// the same result since the linear index and single-axis index are identical.
+    ///
+    /// - Parameter indices: One index per axis.
+    /// - Precondition: `indices.count` equals ``rank``.
     public subscript(indices: Int...) -> Element {
         get { storage[storageIndex(for: indices)] }
         set { storage[storageIndex(for: indices)] = newValue }

--- a/Sources/SwiftMatrix/Tensor.swift
+++ b/Sources/SwiftMatrix/Tensor.swift
@@ -1,11 +1,51 @@
+/// A rank-N multi-dimensional array with flat storage.
+///
+/// `Tensor` stores elements in a contiguous `[Element]` array and uses `shape` and `strides`
+/// to interpret the flat buffer as a multi-dimensional structure. This is the same storage
+/// model used by NumPy and PyTorch.
+///
+/// By default, strides are row-major (C-order): the last axis varies fastest. For a tensor
+/// with shape `[2, 3, 4]`, the strides are `[12, 4, 1]`.
+///
+/// The `offset` property supports zero-copy views. Operations like slicing can produce a new
+/// `Tensor` that shares the same underlying storage but reads from a different starting
+/// position.
+///
+/// ```swift
+/// let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+/// t[1, 2]    // 6
+/// Array(t)   // [1, 2, 3, 4, 5, 6]  (row-major iteration)
+/// ```
 public struct Tensor<Element> {
     var storage: [Element]
+
+    /// The size of each axis.
+    ///
+    /// For a 2x3 matrix, `shape` is `[2, 3]`. A scalar has an empty shape `[]`.
     public let shape: [Int]
+
+    /// The number of elements to skip in storage when advancing one position along each axis.
+    ///
+    /// For row-major layout with shape `[2, 3]`, strides are `[3, 1]`: advancing one step
+    /// along axis 0 skips 3 elements, while advancing along axis 1 skips 1.
     public let strides: [Int]
+
+    /// The starting position in storage for this tensor's data.
+    ///
+    /// Normally `0` for tensors that own their storage. Non-zero offsets arise from
+    /// zero-copy slicing, where a view into a larger buffer starts at a later position.
     public let offset: Int
 
+    /// The number of axes (dimensions).
+    ///
+    /// A scalar has rank 0, a vector has rank 1, a matrix has rank 2, and so on.
     public var rank: Int { shape.count }
 
+    /// Creates a tensor filled with a repeated value.
+    ///
+    /// - Parameters:
+    ///   - shape: The size of each axis. For example, `[2, 3]` creates a 2x3 matrix.
+    ///   - repeatedValue: The value to fill every element with.
     public init(shape: [Int], repeating repeatedValue: Element) {
         let count = shape.reduce(1, *)
         self.storage = Array(repeating: repeatedValue, count: count)
@@ -14,6 +54,14 @@ public struct Tensor<Element> {
         self.offset = 0
     }
 
+    /// Creates a tensor from a flat array of elements and a shape.
+    ///
+    /// The number of elements must equal the product of the shape dimensions.
+    ///
+    /// - Parameters:
+    ///   - shape: The size of each axis.
+    ///   - elements: The elements in row-major order.
+    /// - Precondition: `elements.count` equals the product of `shape`.
     public init(shape: [Int], elements: [Element]) {
         let count = shape.reduce(1, *)
         precondition(elements.count == count,
@@ -24,6 +72,19 @@ public struct Tensor<Element> {
         self.offset = 0
     }
 
+    /// Creates a rank-2 tensor from nested arrays.
+    ///
+    /// The outer array becomes axis 0 (rows) and each inner array becomes axis 1 (columns).
+    /// All inner arrays must have the same length.
+    ///
+    /// ```swift
+    /// let t = Tensor([[1, 2, 3],
+    ///                 [4, 5, 6]])
+    /// // shape: [2, 3]
+    /// ```
+    ///
+    /// - Parameter arrays: The rows of the matrix. Each row must have the same length.
+    /// - Precondition: All inner arrays have equal count.
     public init(_ arrays: [[Element]]) {
         let depth = arrays.count
         guard depth > 0 else {
@@ -36,6 +97,7 @@ public struct Tensor<Element> {
         self.init(shape: [depth, width], elements: arrays.flatMap { $0 })
     }
 
+    /// Creates a tensor with explicit storage layout. Used internally for views.
     init(storage: [Element], shape: [Int], strides: [Int], offset: Int) {
         self.storage = storage
         self.shape = shape
@@ -43,6 +105,10 @@ public struct Tensor<Element> {
         self.offset = offset
     }
 
+    /// Computes row-major (C-order) strides for the given shape.
+    ///
+    /// Each stride is the product of all subsequent dimension sizes. For shape `[2, 3, 4]`,
+    /// returns `[12, 4, 1]`.
     static func computeStrides(for shape: [Int]) -> [Int] {
         guard !shape.isEmpty else { return [] }
         var strides = Array(repeating: 1, count: shape.count)
@@ -52,16 +118,34 @@ public struct Tensor<Element> {
         return strides
     }
 
+    /// Whether this tensor's storage is laid out contiguously in row-major order with no offset.
+    ///
+    /// Contiguous tensors can use the linear index directly as the storage index, avoiding
+    /// the cost of unraveling multi-dimensional coordinates.
     var isContiguous: Bool {
         strides == Self.computeStrides(for: shape) && offset == 0
     }
 
+    /// Converts multi-dimensional indices to a flat storage index.
+    ///
+    /// - Parameter indices: One index per axis.
+    /// - Returns: The position in `storage` for the given coordinates.
+    /// - Precondition: `indices.count` equals ``rank``.
     func storageIndex(for indices: [Int]) -> Int {
         precondition(indices.count == rank,
                      "Expected \(rank) indices, got \(indices.count)")
         return offset + zip(indices, strides).reduce(0) { $0 + $1.0 * $1.1 }
     }
 
+    /// Converts a linear (row-major) index to a flat storage index.
+    ///
+    /// For contiguous tensors, the linear index equals the storage index directly.
+    /// For non-contiguous views (e.g., after transpose), this unravels the linear index
+    /// into multi-dimensional coordinates using the logical shape, then computes the
+    /// physical storage position using the actual strides.
+    ///
+    /// - Parameter linear: A linear index in `0..<count`.
+    /// - Returns: The position in `storage`.
     func storageIndex(forLinearIndex linear: Int) -> Int {
         guard !isContiguous else { return linear }
         var remaining = linear

--- a/Sources/SwiftMatrix/Vector.swift
+++ b/Sources/SwiftMatrix/Vector.swift
@@ -1,13 +1,17 @@
-//
-//  Size.swift
-//  Sandbox
-//
-//  Created by Jake Bromberg on 4/22/21.
-//  Copyright © 2021 Jake Bromberg. All rights reserved.
-//
-
+/// A two-component size descriptor used by ``Matrix``.
+///
+/// `Vector` describes the dimensions of a ``Matrix``, with ``width`` for the number of
+/// columns and ``depth`` for the number of rows.
+///
+/// ```swift
+/// let size = Vector(width: 3, depth: 2)  // 2 rows, 3 columns
+/// let m = Matrix(size: size, repeating: 0)
+/// ```
 public struct Vector: Hashable {
+  /// The number of columns (axis 1 size).
   public let width: Int
+
+  /// The number of rows (axis 0 size).
   public let depth: Int
 
   public init(width: Int, depth: Int) {


### PR DESCRIPTION
## Summary

- Add doc comments to all 7 source files covering every public type, property, initializer, subscript, method, and conditional conformance
- Include usage examples in struct-level docs for `Tensor`, `Matrix`, `Pair`, `Vector`, and `CollectionView`
- Document internal helpers (`computeStrides`, `storageIndex`, `isContiguous`) for contributor clarity
- Note in `Matrix` docs to prefer `Tensor` for new code

Closes #5

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` passes all 35 tests (documentation-only change)