### PR TITLE
Optimize Tensor hot paths for constant-time element access

### DIFF
--- a/Sources/SwiftMatrix/Tensor+Collection.swift
+++ b/Sources/SwiftMatrix/Tensor+Collection.swift
@@ -5,7 +5,7 @@
 /// efficient random access.
 extension Tensor: RandomAccessCollection {
     public var startIndex: Int { 0 }
-    public var endIndex: Int { shape.reduce(1, *) }
+    public var endIndex: Int { count }
 
     /// Accesses the element at the given linear index using an explicit argument label.
     ///
@@ -40,7 +40,7 @@ extension Tensor: RandomAccessCollection {
 /// the same logical shape and elements are considered equal.
 extension Tensor: Equatable where Element: Equatable {
     public static func == (lhs: Tensor, rhs: Tensor) -> Bool {
-        lhs.shape == rhs.shape && Array(lhs) == Array(rhs)
+        lhs.shape == rhs.shape && lhs.elementsEqual(rhs)
     }
 }
 

--- a/Tests/SwiftMatrixTests/TensorCollectionTests.swift
+++ b/Tests/SwiftMatrixTests/TensorCollectionTests.swift
@@ -79,3 +79,17 @@ struct TensorHashableTests {
         #expect(set.count == 2)
     }
 }
+
+struct TensorEquatableNonContiguousTests {
+    @Test func equalDespiteDifferentStrides() {
+        let contiguous = Tensor(shape: [3, 2], elements: [1, 4, 2, 5, 3, 6])
+        let nonContiguous = Tensor(
+            storage: [1, 2, 3, 4, 5, 6],
+            shape: [3, 2],
+            strides: [1, 3],
+            offset: 0,
+            isContiguous: false
+        )
+        #expect(contiguous == nonContiguous)
+    }
+}

--- a/Tests/SwiftMatrixTests/TensorTests.swift
+++ b/Tests/SwiftMatrixTests/TensorTests.swift
@@ -117,3 +117,56 @@ struct TensorEdgeCaseTests {
         #expect(t.strides == [8, 4, 2, 1])
     }
 }
+
+struct TensorContiguityTests {
+    @Test func standardTensorIsContiguous() {
+        let t = Tensor(shape: [2, 3], elements: [1, 2, 3, 4, 5, 6])
+        #expect(t.isContiguous)
+    }
+
+    @Test func scalarIsContiguous() {
+        let t = Tensor(shape: [], elements: [42])
+        #expect(t.isContiguous)
+    }
+
+    @Test func nonContiguousViewReportsNonContiguous() {
+        // A 2x3 tensor with transposed strides [1, 2] instead of row-major [3, 1]
+        let t = Tensor(
+            storage: [1, 2, 3, 4, 5, 6],
+            shape: [3, 2],
+            strides: [1, 3],
+            offset: 0,
+            isContiguous: false
+        )
+        #expect(!t.isContiguous)
+    }
+}
+
+struct TensorNonContiguousAccessTests {
+    @Test func linearIndexOnNonContiguousTensor() {
+        // Simulates a transpose of a 2x3 tensor:
+        // Original (row-major): [[1, 2, 3], [4, 5, 6]]
+        // Transposed shape: [3, 2], strides: [1, 3]
+        // Logical iteration order: (0,0)=1, (0,1)=4, (1,0)=2, (1,1)=5, (2,0)=3, (2,1)=6
+        let t = Tensor(
+            storage: [1, 2, 3, 4, 5, 6],
+            shape: [3, 2],
+            strides: [1, 3],
+            offset: 0,
+            isContiguous: false
+        )
+        #expect(Array(t) == [1, 4, 2, 5, 3, 6])
+    }
+
+    @Test func linearIndexWithOffset() {
+        // A view into a larger storage with offset
+        let t = Tensor(
+            storage: [0, 0, 1, 2, 3, 4, 5, 6],
+            shape: [2, 3],
+            strides: [3, 1],
+            offset: 2,
+            isContiguous: false
+        )
+        #expect(Array(t) == [1, 2, 3, 4, 5, 6])
+    }
+}


### PR DESCRIPTION
## Summary

- Cache `count` and `isContiguous` as stored properties set at init time, eliminating repeated recomputation on every element access
- Return stored `count` from `endIndex` (O(rank) -> O(1))
- Precompute logical strides once in `storageIndex(forLinearIndex:)` instead of per-axis (O(rank^2) -> O(rank))
- Replace `Array(lhs) == Array(rhs)` with `lhs.elementsEqual(rhs)` in Equatable, eliminating two heap allocations

Closes #7

## Test plan

- [x] All 35 existing tests pass unchanged
- [x] 6 new tests covering contiguity tracking and non-contiguous element access:
  - `TensorContiguityTests`: standard, scalar, and non-contiguous cases
  - `TensorNonContiguousAccessTests`: transposed strides, offset views
  - `TensorEquatableNonContiguousTests`: equality across different internal layouts
- [x] `swift build` and `swift test` pass (41 total tests)