### PR TITLE
Add zero-copy Tensor view operations

### DIFF
--- a/Sources/SwiftMatrix/Tensor+Views.swift
+++ b/Sources/SwiftMatrix/Tensor+Views.swift
@@ -1,0 +1,92 @@
+extension Tensor {
+    /// Returns a view with axes reordered according to the given permutation.
+    ///
+    /// This is a zero-copy operation -- the returned tensor shares the same underlying storage
+    /// but has rearranged shape and strides.
+    ///
+    /// ```swift
+    /// let t = Tensor([[1, 2, 3], [4, 5, 6]])  // shape [2, 3]
+    /// let p = t.permuted(axes: [1, 0])         // shape [3, 2]
+    /// Array(p)  // [1, 4, 2, 5, 3, 6]
+    /// ```
+    ///
+    /// - Parameter axes: A permutation of `0..<rank` specifying the new axis order.
+    ///   `axes[i]` is the old axis that becomes new axis `i`.
+    /// - Precondition: `axes` is a valid permutation of `0..<rank`.
+    /// - Returns: A view with permuted axes.
+    public func permuted(axes: [Int]) -> Tensor {
+        precondition(axes.count == rank,
+                     "Expected \(rank) axes, got \(axes.count)")
+        precondition(Set(axes) == Set(0..<rank),
+                     "axes must be a permutation of 0..<\(rank)")
+        let newShape = axes.map { shape[$0] }
+        let newStrides = axes.map { strides[$0] }
+        let contiguous = newStrides == Self.computeStrides(for: newShape) && offset == 0
+        return Tensor(storage: storage, shape: newShape, strides: newStrides,
+                      offset: offset, isContiguous: contiguous)
+    }
+
+    /// Returns a transposed view of a rank-2 tensor.
+    ///
+    /// Equivalent to `permuted(axes: [1, 0])`.
+    ///
+    /// - Precondition: ``rank`` is 2.
+    /// - Returns: A view with rows and columns swapped.
+    public func transposed() -> Tensor {
+        precondition(rank == 2, "transposed() requires rank 2, got rank \(rank)")
+        return permuted(axes: [1, 0])
+    }
+
+    /// Returns a tensor with the same elements but a different shape.
+    ///
+    /// This is a zero-copy operation on contiguous tensors. The elements remain in the same
+    /// order; only the shape and strides change.
+    ///
+    /// ```swift
+    /// let t = Tensor([[1, 2, 3], [4, 5, 6]])  // shape [2, 3]
+    /// let r = t.reshaped(to: [6])              // shape [6]
+    /// Array(r)  // [1, 2, 3, 4, 5, 6]
+    /// ```
+    ///
+    /// - Parameter newShape: The desired shape. Its product must equal ``count``.
+    /// - Precondition: ``isContiguous`` is `true`.
+    /// - Precondition: Product of `newShape` equals ``count``.
+    /// - Returns: A tensor with the new shape.
+    public func reshaped(to newShape: [Int]) -> Tensor {
+        precondition(isContiguous,
+                     "Cannot reshape a non-contiguous tensor; make a contiguous copy first")
+        let newCount = newShape.reduce(1, *)
+        precondition(newCount == count,
+                     "New shape \(newShape) (product \(newCount)) does not match count \(count)")
+        return Tensor(shape: newShape, elements: storage)
+    }
+
+    /// Returns a view selecting a sub-range along one axis.
+    ///
+    /// This is a zero-copy operation -- the returned tensor shares the same underlying storage
+    /// with an adjusted offset and shape.
+    ///
+    /// ```swift
+    /// let t = Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    /// let s = t.slice(axis: 0, range: 1..<3)  // shape [2, 3]
+    /// Array(s)  // [4, 5, 6, 7, 8, 9]
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - axis: The axis to slice along.
+    ///   - range: The range of indices to select along `axis`.
+    /// - Precondition: `axis` is in `0..<rank`.
+    /// - Precondition: `range` is within `0..<shape[axis]`.
+    /// - Returns: A view over the selected sub-range.
+    public func slice(axis: Int, range: Range<Int>) -> Tensor {
+        precondition(axis >= 0 && axis < rank,
+                     "Axis \(axis) out of range for rank \(rank)")
+        precondition(range.lowerBound >= 0 && range.upperBound <= shape[axis],
+                     "Range \(range) out of bounds for axis \(axis) with size \(shape[axis])")
+        var newShape = shape
+        newShape[axis] = range.count
+        let newOffset = offset + range.lowerBound * strides[axis]
+        return Tensor(storage: storage, shape: newShape, strides: strides,
+                      offset: newOffset, isContiguous: false)
+    }
+}

--- a/Tests/SwiftMatrixTests/TensorViewTests.swift
+++ b/Tests/SwiftMatrixTests/TensorViewTests.swift
@@ -1,0 +1,87 @@
+import Testing
+@testable import SwiftMatrix
+
+struct TensorPermuteTests {
+    @Test func permuteRank2() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        let p = t.permuted(axes: [1, 0])
+        #expect(p.shape == [3, 2])
+        #expect(Array(p) == [1, 4, 2, 5, 3, 6])
+    }
+
+    @Test func permuteRank3() {
+        let t = Tensor(shape: [2, 3, 4], elements: Array(1...24))
+        let p = t.permuted(axes: [2, 0, 1])
+        #expect(p.shape == [4, 2, 3])
+        // Original t[0,0,0]=1, t[0,0,1]=2, ...
+        // Permuted: new axis 0 = old axis 2, new axis 1 = old axis 0, new axis 2 = old axis 1
+        // p[0,0,0] = t[0,0,0] = 1
+        // p[0,0,1] = t[0,1,0] = 5
+        // p[0,0,2] = t[0,2,0] = 9
+        // p[0,1,0] = t[1,0,0] = 13
+        #expect(p[0, 0, 0] == 1)
+        #expect(p[0, 0, 1] == 5)
+        #expect(p[0, 0, 2] == 9)
+        #expect(p[0, 1, 0] == 13)
+    }
+
+    @Test func permuteIdentity() {
+        let t = Tensor([[1, 2], [3, 4]])
+        let p = t.permuted(axes: [0, 1])
+        #expect(p.shape == [2, 2])
+        #expect(p.isContiguous)
+        #expect(Array(p) == [1, 2, 3, 4])
+    }
+
+    @Test func transposedRank2() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        let tr = t.transposed()
+        #expect(tr.shape == [3, 2])
+        #expect(Array(tr) == [1, 4, 2, 5, 3, 6])
+    }
+}
+
+struct TensorReshapeTests {
+    @Test(arguments: [
+        (from: [2, 3], to: [6]),
+        (from: [6],    to: [2, 3]),
+        (from: [2, 3], to: [3, 2]),
+        (from: [1, 6], to: [6, 1]),
+    ])
+    func reshapePreservesElements(from: [Int], to: [Int]) {
+        let elements = [1, 2, 3, 4, 5, 6]
+        let t = Tensor(shape: from, elements: elements)
+        let r = t.reshaped(to: to)
+        #expect(r.shape == to)
+        #expect(Array(r) == elements)
+    }
+}
+
+struct TensorSliceTests {
+    @Test func sliceFirstAxis() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        let s = t.slice(axis: 0, range: 1..<3)
+        #expect(s.shape == [2, 3])
+        #expect(Array(s) == [4, 5, 6, 7, 8, 9])
+    }
+
+    @Test func sliceSecondAxis() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        let s = t.slice(axis: 1, range: 0..<2)
+        #expect(s.shape == [2, 2])
+        #expect(Array(s) == [1, 2, 4, 5])
+    }
+
+    @Test func sliceSingleRow() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        let s = t.slice(axis: 0, range: 1..<2)
+        #expect(s.shape == [1, 3])
+        #expect(Array(s) == [4, 5, 6])
+    }
+
+    @Test func slicedThenArray() {
+        let t = Tensor(shape: [4, 3], elements: Array(1...12))
+        let s = t.slice(axis: 0, range: 1..<3)
+        #expect(Array(s) == [4, 5, 6, 7, 8, 9])
+    }
+}


### PR DESCRIPTION
## Summary

- `permuted(axes:)` -- reorder axes by rearranging shape/strides, zero-copy
- `transposed()` -- convenience for rank-2 permute
- `reshaped(to:)` -- change shape on contiguous tensors, zero-copy
- `slice(axis:range:)` -- select sub-range along one axis via offset adjustment, zero-copy

All operations share underlying storage and manipulate shape/strides/offset to reinterpret data without copying.

Closes #9

## Test plan

- [x] All 41 existing tests pass unchanged
- [x] 9 new tests in `TensorViewTests.swift`:
  - `TensorPermuteTests`: rank-2, rank-3, identity (contiguous check), transpose
  - `TensorReshapeTests`: parameterized across 4 shape pairs
  - `TensorSliceTests`: first axis, second axis, single row, slice-then-iterate
- [x] `swift build` and `swift test` pass (50 total tests)