### PR TITLE
Add element-wise Tensor arithmetic

### DIFF
--- a/Sources/SwiftMatrix/Tensor+Arithmetic.swift
+++ b/Sources/SwiftMatrix/Tensor+Arithmetic.swift
@@ -1,0 +1,102 @@
+/// Element-wise arithmetic for tensors with matching shapes.
+///
+/// All operations require operands to have the same shape and produce a new contiguous tensor.
+/// No broadcasting is performed.
+
+private func elementwise<T>(
+    _ lhs: Tensor<T>, _ rhs: Tensor<T>, body: (T, T) -> T
+) -> Tensor<T> {
+    precondition(lhs.shape == rhs.shape,
+                 "Shape mismatch: \(lhs.shape) vs \(rhs.shape)")
+    return Tensor<T>(shape: lhs.shape, elements: zip(lhs, rhs).map(body))
+}
+
+// MARK: - Tensor + Tensor
+
+extension Tensor where Element: AdditiveArithmetic {
+    public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
+        elementwise(lhs, rhs, body: +)
+    }
+
+    public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
+        elementwise(lhs, rhs, body: -)
+    }
+}
+
+extension Tensor where Element: Numeric {
+    public static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
+        elementwise(lhs, rhs, body: *)
+    }
+}
+
+extension Tensor where Element: FloatingPoint {
+    public static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
+        elementwise(lhs, rhs, body: /)
+    }
+}
+
+extension Tensor where Element: SignedNumeric {
+    public static prefix func - (operand: Tensor) -> Tensor {
+        Tensor(shape: operand.shape, elements: operand.map { -$0 })
+    }
+}
+
+// MARK: - Tensor + Scalar / Scalar + Tensor
+
+extension Tensor where Element: AdditiveArithmetic {
+    public static func + (lhs: Tensor, rhs: Element) -> Tensor {
+        Tensor(shape: lhs.shape, elements: lhs.map { $0 + rhs })
+    }
+
+    public static func + (lhs: Element, rhs: Tensor) -> Tensor {
+        Tensor(shape: rhs.shape, elements: rhs.map { lhs + $0 })
+    }
+
+    public static func - (lhs: Tensor, rhs: Element) -> Tensor {
+        Tensor(shape: lhs.shape, elements: lhs.map { $0 - rhs })
+    }
+
+    public static func - (lhs: Element, rhs: Tensor) -> Tensor {
+        Tensor(shape: rhs.shape, elements: rhs.map { lhs - $0 })
+    }
+}
+
+extension Tensor where Element: Numeric {
+    public static func * (lhs: Tensor, rhs: Element) -> Tensor {
+        Tensor(shape: lhs.shape, elements: lhs.map { $0 * rhs })
+    }
+
+    public static func * (lhs: Element, rhs: Tensor) -> Tensor {
+        Tensor(shape: rhs.shape, elements: rhs.map { lhs * $0 })
+    }
+}
+
+extension Tensor where Element: FloatingPoint {
+    public static func / (lhs: Tensor, rhs: Element) -> Tensor {
+        Tensor(shape: lhs.shape, elements: lhs.map { $0 / rhs })
+    }
+}
+
+// MARK: - Compound assignment
+
+extension Tensor where Element: AdditiveArithmetic {
+    public static func += (lhs: inout Tensor, rhs: Tensor) {
+        lhs = lhs + rhs
+    }
+
+    public static func -= (lhs: inout Tensor, rhs: Tensor) {
+        lhs = lhs - rhs
+    }
+}
+
+extension Tensor where Element: Numeric {
+    public static func *= (lhs: inout Tensor, rhs: Tensor) {
+        lhs = lhs * rhs
+    }
+}
+
+extension Tensor where Element: FloatingPoint {
+    public static func /= (lhs: inout Tensor, rhs: Tensor) {
+        lhs = lhs / rhs
+    }
+}

--- a/Tests/SwiftMatrixTests/TensorArithmeticTests.swift
+++ b/Tests/SwiftMatrixTests/TensorArithmeticTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import SwiftMatrix
+
+struct TensorTensorArithmeticTests {
+    @Test func addition() {
+        let a = Tensor(shape: [3], elements: [1, 2, 3])
+        let b = Tensor(shape: [3], elements: [4, 5, 6])
+        #expect(a + b == Tensor(shape: [3], elements: [5, 7, 9]))
+    }
+
+    @Test func subtraction() {
+        let a = Tensor(shape: [3], elements: [4, 5, 6])
+        let b = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(a - b == Tensor(shape: [3], elements: [3, 3, 3]))
+    }
+
+    @Test func multiplication() {
+        let a = Tensor(shape: [2], elements: [2, 3])
+        let b = Tensor(shape: [2], elements: [4, 5])
+        #expect(a * b == Tensor(shape: [2], elements: [8, 15]))
+    }
+
+    @Test func division() {
+        let a = Tensor(shape: [2], elements: [10.0, 20.0])
+        let b = Tensor(shape: [2], elements: [2.0, 5.0])
+        #expect(a / b == Tensor(shape: [2], elements: [5.0, 4.0]))
+    }
+
+    @Test func negation() {
+        let a = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(-a == Tensor(shape: [3], elements: [-1, -2, -3]))
+    }
+}
+
+struct TensorScalarArithmeticTests {
+    @Test func tensorPlusScalar() {
+        let t = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(t + 10 == Tensor(shape: [3], elements: [11, 12, 13]))
+    }
+
+    @Test func scalarPlusTensor() {
+        let t = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(10 + t == Tensor(shape: [3], elements: [11, 12, 13]))
+    }
+
+    @Test func tensorMinusScalar() {
+        let t = Tensor(shape: [3], elements: [10, 20, 30])
+        #expect(t - 1 == Tensor(shape: [3], elements: [9, 19, 29]))
+    }
+
+    @Test func scalarMinusTensor() {
+        let t = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(10 - t == Tensor(shape: [3], elements: [9, 8, 7]))
+    }
+
+    @Test func tensorTimesScalar() {
+        let t = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(t * 3 == Tensor(shape: [3], elements: [3, 6, 9]))
+    }
+
+    @Test func scalarTimesTensor() {
+        let t = Tensor(shape: [3], elements: [1, 2, 3])
+        #expect(3 * t == Tensor(shape: [3], elements: [3, 6, 9]))
+    }
+
+    @Test func tensorDividedByScalar() {
+        let t = Tensor(shape: [2], elements: [10.0, 20.0])
+        #expect(t / 2.0 == Tensor(shape: [2], elements: [5.0, 10.0]))
+    }
+}
+
+struct TensorCompoundAssignmentTests {
+    @Test func plusEquals() {
+        var a = Tensor(shape: [3], elements: [1, 2, 3])
+        a += Tensor(shape: [3], elements: [4, 5, 6])
+        #expect(a == Tensor(shape: [3], elements: [5, 7, 9]))
+    }
+
+    @Test func timesEquals() {
+        var a = Tensor(shape: [2], elements: [2, 3])
+        a *= Tensor(shape: [2], elements: [4, 5])
+        #expect(a == Tensor(shape: [2], elements: [8, 15]))
+    }
+}
+
+struct TensorArithmeticShapeTests {
+    @Test func preservesShapeRank2() {
+        let a = Tensor([[1, 2, 3], [4, 5, 6]])
+        let b = Tensor([[7, 8, 9], [10, 11, 12]])
+        let c = a + b
+        #expect(c.shape == [2, 3])
+        #expect(c == Tensor([[8, 10, 12], [14, 16, 18]]))
+    }
+
+    @Test func worksWithNonContiguous() {
+        // Transposed 2x3 -> 3x2 with non-contiguous strides
+        let t = Tensor(
+            storage: [1, 2, 3, 4, 5, 6],
+            shape: [3, 2],
+            strides: [1, 3],
+            offset: 0,
+            isContiguous: false
+        )
+        let ones = Tensor(shape: [3, 2], repeating: 1)
+        let result = t + ones
+        // t iterates as [1, 4, 2, 5, 3, 6], so result is [2, 5, 3, 6, 4, 7]
+        #expect(Array(result) == [2, 5, 3, 6, 4, 7])
+    }
+}


### PR DESCRIPTION
## Summary

- Tensor-tensor `+`, `-`, `*`, `/` with matching shapes
- Tensor-scalar and scalar-tensor variants for `+`, `-`, `*`, `/`
- Unary negation `-tensor`
- Compound assignment `+=`, `-=`, `*=`, `/=`
- Constrained via `AdditiveArithmetic`, `Numeric`, `FloatingPoint`, `SignedNumeric`

Closes #13

## Test plan

- [x] All 41 existing tests pass unchanged
- [x] 16 new tests in `TensorArithmeticTests.swift`:
  - `TensorTensorArithmeticTests`: +, -, *, /, negation
  - `TensorScalarArithmeticTests`: both directions for +, -, *, and tensor/scalar
  - `TensorCompoundAssignmentTests`: +=, *=
  - `TensorArithmeticShapeTests`: rank-2 shape preservation, non-contiguous input
- [x] `swift build` and `swift test` pass (57 total tests)