### PR TITLE
Add tensor reductions: dot product, matmul, sum, and mean

### DIFF
--- a/Sources/SwiftMatrix/Tensor+Reductions.swift
+++ b/Sources/SwiftMatrix/Tensor+Reductions.swift
@@ -1,0 +1,137 @@
+/// Reductions and linear algebra operations for ``Tensor``.
+
+extension Tensor where Element: Numeric {
+    /// Computes the dot product (inner product) of two rank-1 tensors.
+    ///
+    /// ```swift
+    /// let a = Tensor(shape: [3], elements: [1, 2, 3])
+    /// let b = Tensor(shape: [3], elements: [4, 5, 6])
+    /// Tensor.dot(a, b)  // 32  (1*4 + 2*5 + 3*6)
+    /// ```
+    ///
+    /// - Precondition: Both tensors are rank-1 with the same shape.
+    /// - Returns: The sum of element-wise products.
+    public static func dot(_ lhs: Tensor, _ rhs: Tensor) -> Element {
+        precondition(lhs.rank == 1 && rhs.rank == 1,
+                     "dot requires rank-1 tensors, got ranks \(lhs.rank) and \(rhs.rank)")
+        precondition(lhs.shape == rhs.shape,
+                     "Shape mismatch: \(lhs.shape) vs \(rhs.shape)")
+        return zip(lhs, rhs).reduce(.zero) { $0 + $1.0 * $1.1 }
+    }
+
+    /// Multiplies two rank-2 tensors (matrix multiplication).
+    ///
+    /// ```swift
+    /// let a = Tensor([[1, 2], [3, 4]])       // 2x2
+    /// let b = Tensor([[5, 6], [7, 8]])       // 2x2
+    /// Tensor.matmul(a, b)  // [[19, 22], [43, 50]]
+    /// ```
+    ///
+    /// - Precondition: Both tensors are rank-2 and `lhs.shape[1] == rhs.shape[0]`.
+    /// - Returns: A tensor with shape `[lhs.shape[0], rhs.shape[1]]`.
+    public static func matmul(_ lhs: Tensor, _ rhs: Tensor) -> Tensor {
+        precondition(lhs.rank == 2 && rhs.rank == 2,
+                     "matmul requires rank-2 tensors, got ranks \(lhs.rank) and \(rhs.rank)")
+        let m = lhs.shape[0]
+        let inner = lhs.shape[1]
+        let n = rhs.shape[1]
+        precondition(inner == rhs.shape[0],
+                     "Inner dimensions must match: \(lhs.shape) vs \(rhs.shape)")
+        var result = [Element]()
+        result.reserveCapacity(m * n)
+        for i in 0..<m {
+            for j in 0..<n {
+                var sum: Element = .zero
+                for k in 0..<inner {
+                    sum += lhs[i, k] * rhs[k, j]
+                }
+                result.append(sum)
+            }
+        }
+        return Tensor(shape: [m, n], elements: result)
+    }
+}
+
+// MARK: - Sum
+
+extension Tensor where Element: AdditiveArithmetic {
+    /// Returns the sum of all elements.
+    ///
+    /// ```swift
+    /// Tensor([[1, 2, 3], [4, 5, 6]]).sum()  // 21
+    /// ```
+    public func sum() -> Element {
+        reduce(.zero, +)
+    }
+
+    /// Returns a tensor with one axis collapsed by summation.
+    ///
+    /// The result has rank reduced by 1. For a tensor with shape `[2, 3]`:
+    /// - `sum(axis: 0)` produces shape `[3]` (sum across rows)
+    /// - `sum(axis: 1)` produces shape `[2]` (sum across columns)
+    ///
+    /// - Parameter axis: The axis to sum along.
+    /// - Precondition: `axis` is in `0..<rank`.
+    public func sum(axis: Int) -> Tensor {
+        precondition(axis >= 0 && axis < rank,
+                     "Axis \(axis) out of range for rank \(rank)")
+        var newShape = shape
+        newShape.remove(at: axis)
+        if newShape.isEmpty {
+            return Tensor(shape: [], elements: [sum()])
+        }
+        let axisSize = shape[axis]
+        var result = [Element]()
+        result.reserveCapacity(newShape.reduce(1, *))
+        // Iterate over every index combination in the output shape
+        let outputCount = newShape.reduce(1, *)
+        let outputStrides = Self.computeStrides(for: newShape)
+        for outputLinear in 0..<outputCount {
+            // Convert output linear index to multi-dimensional output indices
+            var outputIndices = [Int]()
+            outputIndices.reserveCapacity(newShape.count)
+            var remaining = outputLinear
+            for s in outputStrides {
+                outputIndices.append(remaining / s)
+                remaining %= s
+            }
+            // Build the full input index by inserting the summed axis
+            var inputIndices = outputIndices
+            inputIndices.insert(0, at: axis)
+            var total: Element = .zero
+            for k in 0..<axisSize {
+                inputIndices[axis] = k
+                total += self[inputIndices]
+            }
+            result.append(total)
+        }
+        return Tensor(shape: newShape, elements: result)
+    }
+}
+
+// MARK: - Mean
+
+extension Tensor where Element: FloatingPoint {
+    /// Returns the arithmetic mean of all elements.
+    ///
+    /// ```swift
+    /// Tensor(shape: [4], elements: [1.0, 2.0, 3.0, 4.0]).mean()  // 2.5
+    /// ```
+    public func mean() -> Element {
+        sum() / Element(count)
+    }
+
+    /// Returns a tensor with one axis collapsed by averaging.
+    ///
+    /// The result has rank reduced by 1. For a tensor with shape `[2, 3]`:
+    /// - `mean(axis: 0)` produces shape `[3]` (mean across rows)
+    /// - `mean(axis: 1)` produces shape `[2]` (mean across columns)
+    ///
+    /// - Parameter axis: The axis to average along.
+    /// - Precondition: `axis` is in `0..<rank`.
+    public func mean(axis: Int) -> Tensor {
+        let s = sum(axis: axis)
+        let divisor = Element(shape[axis])
+        return Tensor(shape: s.shape, elements: s.map { $0 / divisor })
+    }
+}

--- a/Tests/SwiftMatrixTests/TensorReductionTests.swift
+++ b/Tests/SwiftMatrixTests/TensorReductionTests.swift
@@ -1,0 +1,96 @@
+import Testing
+@testable import SwiftMatrix
+
+struct TensorDotProductTests {
+    @Test func dotProductRank1() {
+        let a = Tensor(shape: [3], elements: [1, 2, 3])
+        let b = Tensor(shape: [3], elements: [4, 5, 6])
+        #expect(Tensor.dot(a, b) == 32) // 1*4 + 2*5 + 3*6
+    }
+
+    @Test func dotProductSingleElement() {
+        let a = Tensor(shape: [1], elements: [3])
+        let b = Tensor(shape: [1], elements: [4])
+        #expect(Tensor.dot(a, b) == 12)
+    }
+}
+
+struct TensorMatmulTests {
+    @Test func matmul2x3Times3x2() {
+        let a = Tensor([[1, 2, 3], [4, 5, 6]])         // 2x3
+        let b = Tensor([[7, 8], [9, 10], [11, 12]])     // 3x2
+        let c = Tensor<Int>.matmul(a, b)
+        #expect(c.shape == [2, 2])
+        // [1*7+2*9+3*11, 1*8+2*10+3*12] = [58, 64]
+        // [4*7+5*9+6*11, 4*8+5*10+6*12] = [139, 154]
+        #expect(c == Tensor([[58, 64], [139, 154]]))
+    }
+
+    @Test func matmulIdentity() {
+        let a = Tensor([[1, 2], [3, 4]])
+        let identity = Tensor([[1, 0], [0, 1]])
+        #expect(Tensor<Int>.matmul(a, identity) == a)
+    }
+}
+
+struct TensorSumTests {
+    @Test func sumAll() {
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        #expect(t.sum() == 21)
+    }
+
+    @Test func sumAxis0() {
+        // Sum rows: [[1,2,3],[4,5,6]] -> [5,7,9]
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        let s = t.sum(axis: 0)
+        #expect(s.shape == [3])
+        #expect(s == Tensor(shape: [3], elements: [5, 7, 9]))
+    }
+
+    @Test func sumAxis1() {
+        // Sum columns: [[1,2,3],[4,5,6]] -> [6,15]
+        let t = Tensor([[1, 2, 3], [4, 5, 6]])
+        let s = t.sum(axis: 1)
+        #expect(s.shape == [2])
+        #expect(s == Tensor(shape: [2], elements: [6, 15]))
+    }
+
+    @Test func sumAxis0NonContiguous() {
+        // Transposed 2x3 -> 3x2 with strides [1,3]
+        // Logical elements: [1,4,2,5,3,6]
+        let t = Tensor(
+            storage: [1, 2, 3, 4, 5, 6],
+            shape: [3, 2],
+            strides: [1, 3],
+            offset: 0,
+            isContiguous: false
+        )
+        // sum axis 0: [1+2+3, 4+5+6] = [6, 15]
+        let s = t.sum(axis: 0)
+        #expect(s.shape == [2])
+        #expect(s == Tensor(shape: [2], elements: [6, 15]))
+    }
+}
+
+struct TensorMeanTests {
+    @Test func meanAll() {
+        let t = Tensor(shape: [4], elements: [1.0, 2.0, 3.0, 4.0])
+        #expect(t.mean() == 2.5)
+    }
+
+    @Test func meanAxis0() {
+        // Mean across rows: [[1,2,3],[4,5,6]] -> [2.5, 3.5, 4.5]
+        let t = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        let m = t.mean(axis: 0)
+        #expect(m.shape == [3])
+        #expect(m == Tensor(shape: [3], elements: [2.5, 3.5, 4.5]))
+    }
+
+    @Test func meanAxis1() {
+        // Mean across columns: [[1,2,3],[4,5,6]] -> [2.0, 5.0]
+        let t = Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        let m = t.mean(axis: 1)
+        #expect(m.shape == [2])
+        #expect(m == Tensor(shape: [2], elements: [2.0, 5.0]))
+    }
+}


### PR DESCRIPTION
## Summary

- Add `dot(_:_:)` for rank-1 inner products and `matmul(_:_:)` for rank-2 matrix multiplication
- Add `sum()` / `sum(axis:)` for full and per-axis summation (constrained to `AdditiveArithmetic`)
- Add `mean()` / `mean(axis:)` for full and per-axis averaging (constrained to `FloatingPoint`)
- All axis reductions handle non-contiguous tensor views correctly via stride-aware subscript access
- 11 new tests covering all operations including non-contiguous edge cases

Closes #15

## Test plan

- [x] `dotProductRank1` -- verifies `[1,2,3] . [4,5,6] == 32`
- [x] `dotProductSingleElement` -- single-element dot product
- [x] `matmul2x3Times3x2` -- full matrix multiply with shape/element verification
- [x] `matmulIdentity` -- multiply by identity yields original
- [x] `sumAll` -- full tensor summation
- [x] `sumAxis0` / `sumAxis1` -- per-axis sum with shape verification
- [x] `sumAxis0NonContiguous` -- axis reduction on transposed (non-contiguous) tensor
- [x] `meanAll` / `meanAxis0` / `meanAxis1` -- mean operations
- [x] Full test suite passes (52 tests)