### PR TITLE
Add sparse tensor types: COOTensor and CSRMatrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ Element-wise `+`, `-`, `*`, `/`, negation, scalar variants, compound assignment.
 
 `sum()`, `sum(axis:)`, `mean()`, `mean(axis:)`, `dot(_:_:)`, `matmul(_:_:)`. Constrained on `AdditiveArithmetic`/`Numeric`/`FloatingPoint`.
 
+### Sparse Types
+
+`COOTensor<Element>` stores nonzero entries in Coordinate format using struct-of-arrays layout: `indices[axis][entry]` gives the coordinate along that axis. Entries are sorted in row-major lexicographic order with no duplicates (summed at construction). Works for any rank.
+
+`CSRMatrix<Element>` stores rank-2 sparse matrices in Compressed Sparse Row format: `rowPointers[i]` indexes into parallel `columnIndices` and `values` arrays. Column indices within each row are sorted.
+
+Both are separate types from `Tensor` -- conversions via `init(from:)` and `toTensor()`.
+
 ### Accelerate optimizations
 
 On Apple platforms, `Float` and `Double` tensors use vDSP/CBLAS via the `AccelerateFloatingPoint` protocol. Overload resolution selects the Accelerate path automatically; generic implementations remain as fallbacks for other element types and non-Apple platforms. Wrapped in `#if canImport(Accelerate)`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ Tensor.dot(a, b)     // dot product (rank-1)
 Tensor.matmul(a, b)  // matrix multiply (rank-2)
 ```
 
+### Sparse Types
+
+`COOTensor<Element>` stores sparse tensors of any rank in Coordinate (COO) format. `CSRMatrix<Element>` stores sparse rank-2 matrices in Compressed Sparse Row format.
+
+```swift
+// COO: general-rank sparse tensor
+let coo = COOTensor(
+    shape: [3, 4],
+    indices: [[0, 1, 2], [1, 2, 0]],
+    values: [10, 20, 30]
+)
+coo.nnz       // 3
+coo.density   // 0.25
+
+// CSR: rank-2 sparse matrix
+let csr = CSRMatrix(
+    rows: 3, columns: 3,
+    rowPointers: [0, 2, 3, 4],
+    columnIndices: [0, 2, 2, 0],
+    values: [1, 2, 3, 4]
+)
+
+// Convert between formats
+let dense = coo.toTensor()           // COO -> dense Tensor
+let coo2 = COOTensor(from: dense)    // dense Tensor -> COO
+let csr2 = CSRMatrix(from: dense)    // dense Tensor -> CSR
+let coo3 = COOTensor(from: csr)      // CSR -> COO
+let csr3 = CSRMatrix(from: coo)      // COO -> CSR
+```
+
 ### Accelerate optimizations
 
 On Apple platforms, `Float` and `Double` tensors automatically use vDSP and CBLAS for reductions and matrix multiplication. No API changes required -- overload resolution selects the optimized path. Generic implementations serve as fallbacks for other element types and non-Apple platforms.

--- a/Sources/SwiftMatrix/COOTensor+Conversion.swift
+++ b/Sources/SwiftMatrix/COOTensor+Conversion.swift
@@ -1,0 +1,95 @@
+/// Conversions between `COOTensor` and dense `Tensor`.
+extension COOTensor where Element: AdditiveArithmetic & Equatable {
+    /// Creates a COO tensor from a dense tensor, storing only nonzero entries.
+    ///
+    /// Iterates the tensor in row-major order and records any element that is not `.zero`.
+    /// Works correctly for both contiguous and non-contiguous (e.g., transposed) tensors.
+    ///
+    /// - Parameter tensor: The dense tensor to convert.
+    public init(from tensor: Tensor<Element>) {
+        let shape = tensor.shape
+        let rank = shape.count
+
+        var indices = Array(repeating: [Int](), count: rank)
+        var values = [Element]()
+
+        let strides = Tensor<Element>.computeStrides(for: shape)
+        let count = shape.reduce(1, *)
+
+        for linearIndex in 0..<count {
+            let element = tensor[linearIndex: linearIndex]
+            guard element != .zero else { continue }
+
+            // Unravel linear index into multi-dimensional coordinates
+            var remaining = linearIndex
+            for axis in 0..<rank {
+                let coord: Int
+                if strides[axis] == 0 {
+                    coord = 0
+                } else {
+                    coord = remaining / strides[axis]
+                    remaining %= strides[axis]
+                }
+                indices[axis].append(coord)
+            }
+            values.append(element)
+        }
+
+        // Already in row-major order since we iterated linearly
+        self.init(shape: shape, sortedIndices: indices, values: values)
+    }
+}
+
+/// Conversion from CSR format.
+extension COOTensor {
+    /// Creates a rank-2 COO tensor from a CSR matrix.
+    ///
+    /// Expands the row pointer array into per-entry row indices. The resulting entries
+    /// are already in row-major order since CSR stores rows sequentially.
+    ///
+    /// - Parameter csr: The CSR matrix to convert.
+    public init(from csr: CSRMatrix<Element>) {
+        let shape = [csr.rows, csr.columns]
+        var rowIndices = [Int]()
+        rowIndices.reserveCapacity(csr.nnz)
+
+        for row in 0..<csr.rows {
+            let count = csr.rowPointers[row + 1] - csr.rowPointers[row]
+            rowIndices.append(contentsOf: Array(repeating: row, count: count))
+        }
+
+        self.init(shape: shape, sortedIndices: [rowIndices, csr.columnIndices],
+                  values: csr.values)
+    }
+}
+
+extension COOTensor {
+    /// Converts this COO tensor to a dense tensor, filling unstored positions with `defaultValue`.
+    ///
+    /// - Parameter defaultValue: The value for positions not in the sparse representation.
+    /// - Returns: A dense `Tensor` with the same shape.
+    public func toTensor(defaultValue: Element) -> Tensor<Element> {
+        let count = shape.reduce(1, *)
+        var elements = Array(repeating: defaultValue, count: count)
+        let strides = Tensor<Element>.computeStrides(for: shape)
+
+        for entry in 0..<nnz {
+            var flatIndex = 0
+            for axis in 0..<rank {
+                flatIndex += indices[axis][entry] * strides[axis]
+            }
+            elements[flatIndex] = values[entry]
+        }
+
+        return Tensor(shape: shape, elements: elements)
+    }
+}
+
+extension COOTensor where Element: AdditiveArithmetic {
+    /// Converts this COO tensor to a dense tensor, filling unstored positions with `.zero`.
+    ///
+    /// - Returns: A dense `Tensor` with the same shape.
+    public func toTensor() -> Tensor<Element> {
+        toTensor(defaultValue: .zero)
+    }
+}

--- a/Sources/SwiftMatrix/COOTensor.swift
+++ b/Sources/SwiftMatrix/COOTensor.swift
@@ -1,0 +1,135 @@
+/// A sparse tensor in Coordinate (COO) format.
+///
+/// Stores only the nonzero entries using a struct-of-arrays layout: `indices[axis][entry]`
+/// gives the coordinate along that axis for a given entry. Entries are stored in row-major
+/// lexicographic order with no duplicates (duplicates are summed at construction time).
+///
+/// Works for any rank. For rank-2 sparse matrices, consider ``CSRMatrix`` for more efficient
+/// row-based access patterns.
+///
+/// ```swift
+/// let coo = COOTensor(
+///     shape: [3, 4],
+///     indices: [[0, 1, 2], [1, 2, 0]],
+///     values: [10, 20, 30]
+/// )
+/// coo.nnz      // 3
+/// coo.density   // 0.25
+/// ```
+public struct COOTensor<Element> {
+    /// The size of each axis.
+    public let shape: [Int]
+
+    /// Nonzero entry coordinates in struct-of-arrays layout.
+    ///
+    /// `indices[axis][entry]` gives the coordinate along `axis` for entry at position `entry`.
+    /// Each inner array has length ``nnz``.
+    public let indices: [[Int]]
+
+    /// The nonzero values, parallel to ``indices``.
+    public let values: [Element]
+
+    /// The number of stored (nonzero) entries.
+    public var nnz: Int { values.count }
+
+    /// The number of axes (dimensions).
+    public var rank: Int { shape.count }
+
+    /// The total number of logical elements (product of shape dimensions).
+    public var count: Int { shape.reduce(1, *) }
+
+    /// The fraction of elements that are stored (nonzero).
+    public var density: Double {
+        let total = count
+        guard total > 0 else { return 0 }
+        return Double(nnz) / Double(total)
+    }
+
+    /// Creates a COO tensor from indices and values, sorting entries and summing duplicates.
+    ///
+    /// - Parameters:
+    ///   - shape: The size of each axis.
+    ///   - indices: Struct-of-arrays coordinates. Must have one `[Int]` per axis,
+    ///     each of the same length as `values`.
+    ///   - values: The nonzero values.
+    /// - Precondition: `indices.count` equals the rank, and all inner arrays have length
+    ///   equal to `values.count`.
+    public init(shape: [Int], indices: [[Int]], values: [Element]) where Element: AdditiveArithmetic {
+        precondition(indices.count == shape.count,
+                     "Expected \(shape.count) index arrays, got \(indices.count)")
+        let nnz = values.count
+        precondition(indices.allSatisfy { $0.count == nnz },
+                     "All index arrays must have length \(nnz)")
+
+        if nnz == 0 {
+            self.shape = shape
+            self.indices = indices
+            self.values = values
+            return
+        }
+
+        // Sort entries by row-major lexicographic order
+        let strides = Tensor<Element>.computeStrides(for: shape)
+        var entryOrder = Array(0..<nnz)
+        entryOrder.sort { a, b in
+            for axis in 0..<shape.count {
+                if indices[axis][a] != indices[axis][b] {
+                    return indices[axis][a] < indices[axis][b]
+                }
+            }
+            return false
+        }
+
+        // Apply sort and sum duplicates in one pass
+        var sortedIndices = Array(repeating: [Int](), count: shape.count)
+        var sortedValues = [Element]()
+
+        for i in entryOrder {
+            let isDuplicate: Bool
+            if sortedValues.isEmpty {
+                isDuplicate = false
+            } else {
+                isDuplicate = (0..<shape.count).allSatisfy { axis in
+                    sortedIndices[axis].last! == indices[axis][i]
+                }
+            }
+
+            if isDuplicate {
+                sortedValues[sortedValues.count - 1] = sortedValues[sortedValues.count - 1] + values[i]
+            } else {
+                for axis in 0..<shape.count {
+                    sortedIndices[axis].append(indices[axis][i])
+                }
+                sortedValues.append(values[i])
+            }
+        }
+
+        self.shape = shape
+        self.indices = sortedIndices
+        self.values = sortedValues
+    }
+
+    /// Creates a COO tensor from pre-sorted indices with no duplicates.
+    ///
+    /// This is an internal fast path that skips sorting and deduplication.
+    init(shape: [Int], sortedIndices: [[Int]], values: [Element]) {
+        self.shape = shape
+        self.indices = sortedIndices
+        self.values = values
+    }
+
+    /// Creates an empty COO tensor with the given shape.
+    public init(shape: [Int]) where Element: AdditiveArithmetic {
+        self.shape = shape
+        self.indices = Array(repeating: [], count: shape.count)
+        self.values = []
+    }
+}
+
+extension COOTensor: Sendable where Element: Sendable {}
+
+extension COOTensor: Equatable where Element: Equatable {
+    public static func == (lhs: COOTensor, rhs: COOTensor) -> Bool {
+        lhs.shape == rhs.shape && lhs.indices == rhs.indices && lhs.values == rhs.values
+    }
+}

--- a/Sources/SwiftMatrix/CSRMatrix+Conversion.swift
+++ b/Sources/SwiftMatrix/CSRMatrix+Conversion.swift
@@ -1,0 +1,96 @@
+/// Conversions between `CSRMatrix` and dense `Tensor`.
+extension CSRMatrix where Element: AdditiveArithmetic & Equatable {
+    /// Creates a CSR matrix from a dense rank-2 tensor, storing only nonzero entries.
+    ///
+    /// - Parameter tensor: A rank-2 tensor to convert.
+    /// - Precondition: `tensor.rank == 2`.
+    public init(from tensor: Tensor<Element>) {
+        precondition(tensor.rank == 2, "CSRMatrix requires a rank-2 tensor, got rank \(tensor.rank)")
+
+        let rows = tensor.shape[0]
+        let cols = tensor.shape[1]
+
+        var rowPointers = [Int]()
+        rowPointers.reserveCapacity(rows + 1)
+        var columnIndices = [Int]()
+        var values = [Element]()
+
+        rowPointers.append(0)
+        for row in 0..<rows {
+            for col in 0..<cols {
+                let element = tensor[row, col]
+                if element != .zero {
+                    columnIndices.append(col)
+                    values.append(element)
+                }
+            }
+            rowPointers.append(columnIndices.count)
+        }
+
+        self.init(rows: rows, columns: cols, rowPointers: rowPointers,
+                  columnIndices: columnIndices, values: values)
+    }
+}
+
+/// Conversion from COO format.
+extension CSRMatrix {
+    /// Creates a CSR matrix from a rank-2 COO tensor.
+    ///
+    /// Since COO entries are already sorted in row-major order, this builds the row pointer
+    /// array by scanning the sorted row indices.
+    ///
+    /// - Parameter coo: A rank-2 COO tensor to convert.
+    /// - Precondition: `coo.rank == 2`.
+    public init(from coo: COOTensor<Element>) {
+        precondition(coo.rank == 2, "CSRMatrix requires a rank-2 COO tensor, got rank \(coo.rank)")
+
+        let rows = coo.shape[0]
+        let cols = coo.shape[1]
+        let rowIndices = coo.indices[0]
+        let colIndices = coo.indices[1]
+
+        var rowPointers = Array(repeating: 0, count: rows + 1)
+
+        // Count entries per row
+        for row in rowIndices {
+            rowPointers[row + 1] += 1
+        }
+        // Cumulative sum
+        for i in 1...rows {
+            rowPointers[i] += rowPointers[i - 1]
+        }
+
+        self.init(rows: rows, columns: cols, rowPointers: rowPointers,
+                  columnIndices: colIndices, values: coo.values)
+    }
+}
+
+extension CSRMatrix {
+    /// Converts this CSR matrix to a dense rank-2 tensor, filling unstored positions
+    /// with `defaultValue`.
+    ///
+    /// - Parameter defaultValue: The value for positions not in the sparse representation.
+    /// - Returns: A dense rank-2 `Tensor` with shape `[rows, columns]`.
+    public func toTensor(defaultValue: Element) -> Tensor<Element> {
+        var elements = Array(repeating: defaultValue, count: rows * columns)
+
+        for row in 0..<rows {
+            for idx in rowPointers[row]..<rowPointers[row + 1] {
+                let col = columnIndices[idx]
+                elements[row * columns + col] = values[idx]
+            }
+        }
+
+        return Tensor(shape: [rows, columns], elements: elements)
+    }
+}
+
+extension CSRMatrix where Element: AdditiveArithmetic {
+    /// Converts this CSR matrix to a dense rank-2 tensor, filling unstored positions
+    /// with `.zero`.
+    ///
+    /// - Returns: A dense rank-2 `Tensor` with shape `[rows, columns]`.
+    public func toTensor() -> Tensor<Element> {
+        toTensor(defaultValue: .zero)
+    }
+}

--- a/Sources/SwiftMatrix/CSRMatrix.swift
+++ b/Sources/SwiftMatrix/CSRMatrix.swift
@@ -1,0 +1,100 @@
+/// A sparse rank-2 matrix in Compressed Sparse Row (CSR) format.
+///
+/// Stores nonzero entries using three parallel arrays: `rowPointers` indexes into
+/// `columnIndices` and `values` to locate the entries for each row. Column indices
+/// within each row are sorted.
+///
+/// For general-rank sparse data, use ``COOTensor``.
+///
+/// ```swift
+/// // [[1, 0, 2],
+/// //  [0, 0, 3],
+/// //  [4, 0, 0]]
+/// let csr = CSRMatrix(
+///     rows: 3, columns: 3,
+///     rowPointers: [0, 2, 3, 4],
+///     columnIndices: [0, 2, 2, 0],
+///     values: [1, 2, 3, 4]
+/// )
+/// ```
+public struct CSRMatrix<Element> {
+    /// The number of rows.
+    public let rows: Int
+
+    /// The number of columns.
+    public let columns: Int
+
+    /// Row pointer array of length `rows + 1`.
+    ///
+    /// The entries for row `i` are stored at positions `rowPointers[i]..<rowPointers[i+1]`
+    /// in ``columnIndices`` and ``values``.
+    public let rowPointers: [Int]
+
+    /// Column indices of nonzero entries, sorted within each row.
+    public let columnIndices: [Int]
+
+    /// The nonzero values, parallel to ``columnIndices``.
+    public let values: [Element]
+
+    /// The number of stored (nonzero) entries.
+    public var nnz: Int { values.count }
+
+    /// The shape as `[rows, columns]`, for compatibility with ``Tensor`` conventions.
+    public var shape: [Int] { [rows, columns] }
+
+    /// The total number of logical elements (`rows * columns`).
+    public var count: Int { rows * columns }
+
+    /// The fraction of elements that are stored (nonzero).
+    public var density: Double {
+        let total = count
+        guard total > 0 else { return 0 }
+        return Double(nnz) / Double(total)
+    }
+
+    /// Creates a CSR matrix from pre-built arrays.
+    ///
+    /// - Parameters:
+    ///   - rows: The number of rows.
+    ///   - columns: The number of columns.
+    ///   - rowPointers: Row pointer array of length `rows + 1`.
+    ///   - columnIndices: Column indices, sorted within each row.
+    ///   - values: Nonzero values, parallel to `columnIndices`.
+    /// - Precondition: `rowPointers` has length `rows + 1`, `columnIndices` and `values`
+    ///   have the same length, and `rowPointers.last == columnIndices.count`.
+    public init(rows: Int, columns: Int, rowPointers: [Int], columnIndices: [Int], values: [Element]) {
+        precondition(rowPointers.count == rows + 1,
+                     "rowPointers must have length \(rows + 1), got \(rowPointers.count)")
+        precondition(columnIndices.count == values.count,
+                     "columnIndices and values must have the same length")
+        precondition(rowPointers.last == columnIndices.count,
+                     "rowPointers.last must equal columnIndices.count")
+
+        self.rows = rows
+        self.columns = columns
+        self.rowPointers = rowPointers
+        self.columnIndices = columnIndices
+        self.values = values
+    }
+
+    /// Creates an empty CSR matrix with the given dimensions.
+    public init(rows: Int, columns: Int) {
+        self.rows = rows
+        self.columns = columns
+        self.rowPointers = Array(repeating: 0, count: rows + 1)
+        self.columnIndices = []
+        self.values = []
+    }
+}
+
+extension CSRMatrix: Sendable where Element: Sendable {}
+
+extension CSRMatrix: Equatable where Element: Equatable {
+    public static func == (lhs: CSRMatrix, rhs: CSRMatrix) -> Bool {
+        lhs.rows == rhs.rows
+            && lhs.columns == rhs.columns
+            && lhs.rowPointers == rhs.rowPointers
+            && lhs.columnIndices == rhs.columnIndices
+            && lhs.values == rhs.values
+    }
+}

--- a/Tests/SwiftMatrixTests/COOTensorConversionTests.swift
+++ b/Tests/SwiftMatrixTests/COOTensorConversionTests.swift
@@ -1,0 +1,134 @@
+import Testing
+@testable import SwiftMatrix
+
+struct COOTensorDenseConversionTests {
+    @Test func toDenseRank1() {
+        let coo = COOTensor(
+            shape: [5],
+            indices: [[1, 3]],
+            values: [3, 7]
+        )
+        let dense = coo.toTensor()
+        #expect(dense == Tensor(shape: [5], elements: [0, 3, 0, 7, 0]))
+    }
+
+    @Test func toDenseRank2() {
+        let coo = COOTensor(
+            shape: [2, 3],
+            indices: [[0, 1], [2, 0]],
+            values: [5, 10]
+        )
+        let dense = coo.toTensor()
+        #expect(dense == Tensor(shape: [2, 3], elements: [0, 0, 5, 10, 0, 0]))
+    }
+
+    @Test func toDenseRank3() {
+        let coo = COOTensor(
+            shape: [2, 2, 2],
+            indices: [[0, 1], [1, 0], [0, 1]],
+            values: [5, 10]
+        )
+        let dense = coo.toTensor()
+        // (0,1,0) -> flat index 2, (1,0,1) -> flat index 5
+        #expect(dense == Tensor(shape: [2, 2, 2], elements: [0, 0, 5, 0, 0, 10, 0, 0]))
+    }
+
+    @Test(arguments: [
+        (
+            shape: [5],
+            elements: [0, 3, 0, 0, 7],
+            label: "rank-1 sparse vector"
+        ),
+        (
+            shape: [3, 4],
+            elements: [1, 0, 0, 2, 0, 0, 3, 0, 0, 4, 0, 0],
+            label: "rank-2 sparse matrix"
+        ),
+        (
+            shape: [2, 2],
+            elements: [0, 0, 0, 0],
+            label: "rank-2 all zeros"
+        ),
+        (
+            shape: [2, 2],
+            elements: [1, 2, 3, 4],
+            label: "rank-2 fully dense"
+        ),
+    ])
+    func roundTrip(shape: [Int], elements: [Int], label: String) {
+        let original = Tensor(shape: shape, elements: elements)
+        let coo = COOTensor(from: original)
+        let reconstructed = coo.toTensor()
+        #expect(reconstructed == original)
+    }
+
+    @Test func emptyTensor() {
+        let coo = COOTensor<Int>(shape: [0, 3])
+        let dense = coo.toTensor()
+        #expect(dense.shape == [0, 3])
+        #expect(dense.count == 0)
+    }
+
+    @Test func allZeroTensor() {
+        let original = Tensor(shape: [2, 2], repeating: 0)
+        let coo = COOTensor(from: original)
+        #expect(coo.nnz == 0)
+        #expect(coo.toTensor() == original)
+    }
+
+    @Test func fullyDenseTensor() {
+        let original = Tensor(shape: [2, 2], elements: [1, 2, 3, 4])
+        let coo = COOTensor(from: original)
+        #expect(coo.nnz == 4)
+        #expect(coo.toTensor() == original)
+    }
+
+    @Test func toDenseWithCustomDefault() {
+        let coo = COOTensor(
+            shape: [3],
+            indices: [[1]],
+            values: [5]
+        )
+        let dense = coo.toTensor(defaultValue: -1)
+        #expect(dense == Tensor(shape: [3], elements: [-1, 5, -1]))
+    }
+
+    @Test func nonContiguousTensorInput() {
+        // Create a 2x3 tensor and transpose it to 3x2
+        let original = Tensor([[1, 0, 3], [0, 5, 0]])
+        let transposed = original.transposed()
+        // transposed: [[1, 0], [0, 5], [3, 0]]
+        let coo = COOTensor(from: transposed)
+        #expect(coo.shape == [3, 2])
+        // Nonzeros: (0,0)=1, (1,1)=5, (2,0)=3
+        #expect(coo.nnz == 3)
+        #expect(coo.toTensor() == Tensor(shape: [3, 2], elements: [1, 0, 0, 5, 3, 0]))
+    }
+}
+
+struct COOTensorCSRConversionTests {
+    @Test func fromCSRMatrix() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [1, 2, 3, 4]
+        )
+        let coo = COOTensor(from: csr)
+        #expect(coo.shape == [3, 3])
+        #expect(coo.nnz == 4)
+        #expect(coo.indices == [[0, 0, 1, 2], [0, 2, 2, 0]])
+        #expect(coo.values == [1, 2, 3, 4])
+    }
+
+    @Test func roundTripCOOToCSRToCOO() {
+        let original = COOTensor(
+            shape: [3, 4],
+            indices: [[0, 0, 1, 2, 2], [0, 3, 2, 1, 3]],
+            values: [1, 2, 3, 4, 5]
+        )
+        let csr = CSRMatrix(from: original)
+        let reconstructed = COOTensor(from: csr)
+        #expect(reconstructed == original)
+    }
+}

--- a/Tests/SwiftMatrixTests/COOTensorTests.swift
+++ b/Tests/SwiftMatrixTests/COOTensorTests.swift
@@ -1,0 +1,130 @@
+import Testing
+@testable import SwiftMatrix
+
+struct COOTensorCreationTests {
+    @Test func createEmpty() {
+        let coo = COOTensor<Int>(shape: [3, 4])
+        #expect(coo.shape == [3, 4])
+        #expect(coo.nnz == 0)
+        #expect(coo.indices.count == 2)
+        #expect(coo.indices[0].isEmpty)
+        #expect(coo.indices[1].isEmpty)
+        #expect(coo.values.isEmpty)
+    }
+
+    @Test func createFromIndicesAndValues() {
+        let coo = COOTensor(
+            shape: [3, 4],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [10, 20, 30]
+        )
+        #expect(coo.shape == [3, 4])
+        #expect(coo.nnz == 3)
+        #expect(coo.indices == [[0, 1, 2], [1, 2, 0]])
+        #expect(coo.values == [10, 20, 30])
+    }
+
+    @Test func sortsEntriesByRowMajorOrder() {
+        // Pass entries in reverse order
+        let coo = COOTensor(
+            shape: [3, 3],
+            indices: [[2, 0, 1], [1, 2, 0]],
+            values: [30, 10, 20]
+        )
+        // Should be sorted to (0,2), (1,0), (2,1)
+        #expect(coo.indices == [[0, 1, 2], [2, 0, 1]])
+        #expect(coo.values == [10, 20, 30])
+    }
+
+    @Test func sumsDuplicateEntries() {
+        // Two entries at (1, 2) with values 10 and 25
+        let coo = COOTensor(
+            shape: [3, 3],
+            indices: [[1, 0, 1], [2, 0, 2]],
+            values: [10, 5, 25]
+        )
+        // After sorting and summing: (0,0)=5, (1,2)=35
+        #expect(coo.nnz == 2)
+        #expect(coo.indices == [[0, 1], [0, 2]])
+        #expect(coo.values == [5, 35])
+    }
+
+    @Test func propertiesNnzRankCountDensity() {
+        let coo = COOTensor(
+            shape: [4, 5],
+            indices: [[0, 2, 3], [1, 3, 0]],
+            values: [1, 2, 3]
+        )
+        #expect(coo.nnz == 3)
+        #expect(coo.rank == 2)
+        #expect(coo.count == 20)
+        #expect(coo.density == 3.0 / 20.0)
+    }
+
+    @Test func rank1Sparse() {
+        let coo = COOTensor(
+            shape: [5],
+            indices: [[1, 3]],
+            values: [10, 20]
+        )
+        #expect(coo.rank == 1)
+        #expect(coo.nnz == 2)
+        #expect(coo.indices == [[1, 3]])
+        #expect(coo.values == [10, 20])
+    }
+
+    @Test func rank3Sparse() {
+        let coo = COOTensor(
+            shape: [2, 3, 4],
+            indices: [[0, 1], [2, 0], [3, 1]],
+            values: [10, 20]
+        )
+        #expect(coo.rank == 3)
+        #expect(coo.nnz == 2)
+        #expect(coo.shape == [2, 3, 4])
+    }
+}
+
+struct COOTensorEquatableTests {
+    @Test func equalTensors() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        #expect(a == b)
+    }
+
+    @Test func differentValues() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 99]
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentShapes() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0], [1]],
+            values: [10]
+        )
+        let b = COOTensor(
+            shape: [4, 4],
+            indices: [[0], [1]],
+            values: [10]
+        )
+        #expect(a != b)
+    }
+}

--- a/Tests/SwiftMatrixTests/CSRMatrixConversionTests.swift
+++ b/Tests/SwiftMatrixTests/CSRMatrixConversionTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import SwiftMatrix
+
+struct CSRMatrixDenseConversionTests {
+    @Test func toDenseSmall() {
+        // [[1, 0, 2],
+        //  [0, 0, 3],
+        //  [4, 0, 0]]
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [1, 2, 3, 4]
+        )
+        let dense = csr.toTensor()
+        #expect(dense == Tensor([[1, 0, 2], [0, 0, 3], [4, 0, 0]]))
+    }
+
+    @Test func toDenseIdentity() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 2],
+            values: [1, 1, 1]
+        )
+        let dense = csr.toTensor()
+        #expect(dense == Tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
+    }
+
+    @Test(arguments: [
+        (
+            elements: [[1, 0, 0, 2], [0, 0, 3, 0], [0, 4, 0, 0]],
+            label: "sparse"
+        ),
+        (
+            elements: [[0, 0], [0, 0]],
+            label: "all zeros"
+        ),
+        (
+            elements: [[1, 2], [3, 4]],
+            label: "fully dense"
+        ),
+        (
+            elements: [[0, 0, 7, 0, 0]],
+            label: "single row"
+        ),
+    ])
+    func roundTrip(elements: [[Int]], label: String) {
+        let original = Tensor(elements)
+        let csr = CSRMatrix(from: original)
+        let reconstructed = csr.toTensor()
+        #expect(reconstructed == original)
+    }
+
+    @Test func emptyMatrix() {
+        let csr = CSRMatrix<Int>(rows: 0, columns: 3)
+        let dense = csr.toTensor()
+        #expect(dense.shape == [0, 3])
+        #expect(dense.count == 0)
+    }
+}
+
+struct CSRMatrixCOOConversionTests {
+    @Test func fromCOOTensor() {
+        let coo = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [0, 2, 1]],
+            values: [1, 2, 3]
+        )
+        let csr = CSRMatrix(from: coo)
+        #expect(csr.rows == 3)
+        #expect(csr.columns == 3)
+        #expect(csr.rowPointers == [0, 1, 2, 3])
+        #expect(csr.columnIndices == [0, 2, 1])
+        #expect(csr.values == [1, 2, 3])
+    }
+
+    @Test func roundTripCSRToCOOToCSR() {
+        let original = CSRMatrix(
+            rows: 3, columns: 4,
+            rowPointers: [0, 2, 3, 5],
+            columnIndices: [0, 3, 2, 1, 3],
+            values: [1, 2, 3, 4, 5]
+        )
+        let coo = COOTensor(from: original)
+        let reconstructed = CSRMatrix(from: coo)
+        #expect(reconstructed == original)
+    }
+}

--- a/Tests/SwiftMatrixTests/CSRMatrixTests.swift
+++ b/Tests/SwiftMatrixTests/CSRMatrixTests.swift
@@ -1,0 +1,131 @@
+import Testing
+@testable import SwiftMatrix
+
+struct CSRMatrixCreationTests {
+    @Test func createEmpty() {
+        let csr = CSRMatrix<Int>(rows: 3, columns: 4)
+        #expect(csr.rows == 3)
+        #expect(csr.columns == 4)
+        #expect(csr.nnz == 0)
+        #expect(csr.rowPointers == [0, 0, 0, 0])
+        #expect(csr.columnIndices.isEmpty)
+        #expect(csr.values.isEmpty)
+    }
+
+    @Test func createFromArrays() {
+        // [[1, 0, 2],
+        //  [0, 0, 3],
+        //  [4, 0, 0]]
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [1, 2, 3, 4]
+        )
+        #expect(csr.rows == 3)
+        #expect(csr.columns == 3)
+        #expect(csr.nnz == 4)
+        #expect(csr.rowPointers == [0, 2, 3, 4])
+        #expect(csr.columnIndices == [0, 2, 2, 0])
+        #expect(csr.values == [1, 2, 3, 4])
+    }
+
+    @Test func identityMatrix() {
+        // 3x3 identity
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 2],
+            values: [1, 1, 1]
+        )
+        #expect(csr.nnz == 3)
+        #expect(csr.shape == [3, 3])
+    }
+
+    @Test func propertiesNnzRowsColumns() {
+        let csr = CSRMatrix(
+            rows: 4, columns: 5,
+            rowPointers: [0, 2, 2, 3, 5],
+            columnIndices: [0, 3, 2, 1, 4],
+            values: [1, 2, 3, 4, 5]
+        )
+        #expect(csr.nnz == 5)
+        #expect(csr.rows == 4)
+        #expect(csr.columns == 5)
+        #expect(csr.shape == [4, 5])
+        #expect(csr.count == 20)
+    }
+
+    @Test func densityCalculation() {
+        let csr = CSRMatrix(
+            rows: 2, columns: 5,
+            rowPointers: [0, 2, 3],
+            columnIndices: [1, 3, 4],
+            values: [10, 20, 30]
+        )
+        #expect(csr.density == 3.0 / 10.0)
+    }
+
+    @Test func emptyRows() {
+        // Row 1 has no entries
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 1, 1, 2],
+            columnIndices: [0, 2],
+            values: [1, 2]
+        )
+        #expect(csr.nnz == 2)
+        // Row 1 range: rowPointers[1]..<rowPointers[2] == 1..<1 (empty)
+        #expect(csr.rowPointers[1] == csr.rowPointers[2])
+    }
+}
+
+struct CSRMatrixEquatableTests {
+    @Test func equalMatrices() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        #expect(a == b)
+    }
+
+    @Test func differentValues() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 99]
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentStructure() {
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 2],
+            values: [1, 2]
+        )
+        #expect(a != b)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `COOTensor<Element>` for general-rank sparse tensors in Coordinate format (struct-of-arrays layout, sorted entries, duplicates summed)
- Add `CSRMatrix<Element>` for rank-2 sparse matrices in Compressed Sparse Row format
- Implement conversions: dense Tensor <-> COO, dense Tensor <-> CSR, COO <-> CSR
- Add conditional `Equatable` and `Sendable` conformances for both types

Closes #25

## Test plan

- [x] COOTensor creation: empty, from indices/values, sorting, duplicate summing, rank-1/rank-3
- [x] COOTensor equatable: equal, different values, different shapes
- [x] COOTensor dense conversions: rank-1/2/3 toDense, round-trips (parameterized), edge cases (empty, all-zero, fully dense, custom default, non-contiguous input)
- [x] CSRMatrix creation: empty, from arrays, identity, properties, empty rows
- [x] CSRMatrix equatable: equal, different values, different structure
- [x] CSRMatrix dense conversions: small/identity toDense, round-trips (parameterized), empty matrix
- [x] Cross-format: COO from CSR, CSR from COO, round-trips both directions
- [x] All 120 tests pass (33 suites)