### PR TITLE
Add element-wise arithmetic for COOTensor and CSRMatrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Element-wise `+`, `-`, `*`, `/`, negation, scalar variants, compound assignment.
 
 Both are separate types from `Tensor` -- conversions via `init(from:)` and `toTensor()`.
 
+Element-wise `+`, `-`, `*`, scalar `*`, scalar `/`, negation, and compound assignment (`+=`, `-=`, `*=`). Uses two-pointer merge (addition/subtraction) and intersection (multiplication) on sorted entries for O(nnz_a + nnz_b) performance. No `sparse + scalar` (densifies) or `sparse / sparse` (divide by implicit zero).
+
 ### Performance
 
 - `logicalStrides: [Int]` cached at init time (avoids per-access `computeStrides` allocations)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ let coo2 = COOTensor(from: dense)    // dense Tensor -> COO
 let csr2 = CSRMatrix(from: dense)    // dense Tensor -> CSR
 let coo3 = COOTensor(from: csr)      // CSR -> COO
 let csr3 = CSRMatrix(from: coo)      // COO -> CSR
+
+// Sparse arithmetic (same API for both COO and CSR)
+let sum = coo + coo2       // element-wise addition
+let diff = coo - coo2      // element-wise subtraction
+let prod = coo * coo2      // element-wise multiplication (intersection)
+let scaled = coo * 3       // scalar multiply
+let divided = coo / 2.0    // scalar divide (FloatingPoint)
+let neg = -coo             // negation
 ```
 
 ### Accelerate optimizations

--- a/Sources/SwiftMatrix/COOTensor+Arithmetic.swift
+++ b/Sources/SwiftMatrix/COOTensor+Arithmetic.swift
@@ -1,0 +1,180 @@
+/// Element-wise arithmetic for COO sparse tensors.
+///
+/// All operations require operands to have the same shape. No broadcasting is performed.
+/// Sparse + scalar and sparse - scalar are intentionally omitted because they would
+/// produce dense results. Sparse / sparse is omitted because it would divide by implicit zeros.
+
+/// Computes a scalar linear index for one COO entry using row-major strides.
+private func cooLinearIndex<Element>(
+    _ tensor: COOTensor<Element>, entry: Int, strides: [Int]
+) -> Int {
+    var index = 0
+    for axis in 0..<tensor.rank {
+        index += tensor.indices[axis][entry] * strides[axis]
+    }
+    return index
+}
+
+/// Two-pointer merge of two COO tensors, producing a sorted COO result.
+///
+/// For entries present in both operands, `body` combines the values.
+/// For entries in only the left operand, `lhsOnly` transforms the value.
+/// For entries in only the right operand, `rhsOnly` transforms the value.
+private func cooMerge<Element>(
+    _ lhs: COOTensor<Element>,
+    _ rhs: COOTensor<Element>,
+    body: (Element, Element) -> Element,
+    lhsOnly: (Element) -> Element,
+    rhsOnly: (Element) -> Element
+) -> COOTensor<Element> {
+    precondition(lhs.shape == rhs.shape,
+                 "Shape mismatch: \(lhs.shape) vs \(rhs.shape)")
+
+    let strides = Tensor<Element>.computeStrides(for: lhs.shape)
+    let rank = lhs.rank
+
+    var resultIndices = Array(repeating: [Int](), count: rank)
+    var resultValues = [Element]()
+
+    var i = 0, j = 0
+    while i < lhs.nnz && j < rhs.nnz {
+        let li = cooLinearIndex(lhs, entry: i, strides: strides)
+        let lj = cooLinearIndex(rhs, entry: j, strides: strides)
+
+        if li < lj {
+            for axis in 0..<rank {
+                resultIndices[axis].append(lhs.indices[axis][i])
+            }
+            resultValues.append(lhsOnly(lhs.values[i]))
+            i += 1
+        } else if li > lj {
+            for axis in 0..<rank {
+                resultIndices[axis].append(rhs.indices[axis][j])
+            }
+            resultValues.append(rhsOnly(rhs.values[j]))
+            j += 1
+        } else {
+            for axis in 0..<rank {
+                resultIndices[axis].append(lhs.indices[axis][i])
+            }
+            resultValues.append(body(lhs.values[i], rhs.values[j]))
+            i += 1
+            j += 1
+        }
+    }
+
+    while i < lhs.nnz {
+        for axis in 0..<rank {
+            resultIndices[axis].append(lhs.indices[axis][i])
+        }
+        resultValues.append(lhsOnly(lhs.values[i]))
+        i += 1
+    }
+
+    while j < rhs.nnz {
+        for axis in 0..<rank {
+            resultIndices[axis].append(rhs.indices[axis][j])
+        }
+        resultValues.append(rhsOnly(rhs.values[j]))
+        j += 1
+    }
+
+    return COOTensor(shape: lhs.shape, sortedIndices: resultIndices, values: resultValues)
+}
+
+/// Two-pointer intersection of two COO tensors (matching indices only).
+private func cooIntersect<Element>(
+    _ lhs: COOTensor<Element>,
+    _ rhs: COOTensor<Element>,
+    body: (Element, Element) -> Element
+) -> COOTensor<Element> {
+    precondition(lhs.shape == rhs.shape,
+                 "Shape mismatch: \(lhs.shape) vs \(rhs.shape)")
+
+    let strides = Tensor<Element>.computeStrides(for: lhs.shape)
+    let rank = lhs.rank
+
+    var resultIndices = Array(repeating: [Int](), count: rank)
+    var resultValues = [Element]()
+
+    var i = 0, j = 0
+    while i < lhs.nnz && j < rhs.nnz {
+        let li = cooLinearIndex(lhs, entry: i, strides: strides)
+        let lj = cooLinearIndex(rhs, entry: j, strides: strides)
+
+        if li < lj {
+            i += 1
+        } else if li > lj {
+            j += 1
+        } else {
+            for axis in 0..<rank {
+                resultIndices[axis].append(lhs.indices[axis][i])
+            }
+            resultValues.append(body(lhs.values[i], rhs.values[j]))
+            i += 1
+            j += 1
+        }
+    }
+
+    return COOTensor(shape: lhs.shape, sortedIndices: resultIndices, values: resultValues)
+}
+
+// MARK: - COOTensor + COOTensor
+
+extension COOTensor where Element: AdditiveArithmetic {
+    public static func + (lhs: COOTensor, rhs: COOTensor) -> COOTensor {
+        cooMerge(lhs, rhs, body: +, lhsOnly: { $0 }, rhsOnly: { $0 })
+    }
+
+    public static func - (lhs: COOTensor, rhs: COOTensor) -> COOTensor {
+        cooMerge(lhs, rhs, body: -, lhsOnly: { $0 }, rhsOnly: { .zero - $0 })
+    }
+}
+
+extension COOTensor where Element: Numeric {
+    public static func * (lhs: COOTensor, rhs: COOTensor) -> COOTensor {
+        cooIntersect(lhs, rhs, body: *)
+    }
+}
+
+extension COOTensor where Element: SignedNumeric {
+    public static prefix func - (operand: COOTensor) -> COOTensor {
+        COOTensor(shape: operand.shape, sortedIndices: operand.indices, values: operand.values.map { -$0 })
+    }
+}
+
+// MARK: - COOTensor + Scalar / Scalar + COOTensor
+
+extension COOTensor where Element: Numeric {
+    public static func * (lhs: COOTensor, rhs: Element) -> COOTensor {
+        COOTensor(shape: lhs.shape, sortedIndices: lhs.indices, values: lhs.values.map { $0 * rhs })
+    }
+
+    public static func * (lhs: Element, rhs: COOTensor) -> COOTensor {
+        COOTensor(shape: rhs.shape, sortedIndices: rhs.indices, values: rhs.values.map { lhs * $0 })
+    }
+}
+
+extension COOTensor where Element: FloatingPoint {
+    public static func / (lhs: COOTensor, rhs: Element) -> COOTensor {
+        COOTensor(shape: lhs.shape, sortedIndices: lhs.indices, values: lhs.values.map { $0 / rhs })
+    }
+}
+
+// MARK: - Compound assignment
+
+extension COOTensor where Element: AdditiveArithmetic {
+    public static func += (lhs: inout COOTensor, rhs: COOTensor) {
+        lhs = lhs + rhs
+    }
+
+    public static func -= (lhs: inout COOTensor, rhs: COOTensor) {
+        lhs = lhs - rhs
+    }
+}
+
+extension COOTensor where Element: Numeric {
+    public static func *= (lhs: inout COOTensor, rhs: COOTensor) {
+        lhs = lhs * rhs
+    }
+}

--- a/Sources/SwiftMatrix/CSRMatrix+Arithmetic.swift
+++ b/Sources/SwiftMatrix/CSRMatrix+Arithmetic.swift
@@ -1,0 +1,193 @@
+/// Element-wise arithmetic for CSR sparse matrices.
+///
+/// All operations require operands to have the same dimensions. No broadcasting is performed.
+/// Sparse + scalar and sparse - scalar are intentionally omitted because they would
+/// produce dense results. Sparse / sparse is omitted because it would divide by implicit zeros.
+
+/// Row-by-row two-pointer merge of two CSR matrices.
+///
+/// For entries present in both operands, `body` combines the values.
+/// For entries in only the left operand, `lhsOnly` transforms the value.
+/// For entries in only the right operand, `rhsOnly` transforms the value.
+private func csrMerge<Element>(
+    _ lhs: CSRMatrix<Element>,
+    _ rhs: CSRMatrix<Element>,
+    body: (Element, Element) -> Element,
+    lhsOnly: (Element) -> Element,
+    rhsOnly: (Element) -> Element
+) -> CSRMatrix<Element> {
+    precondition(lhs.rows == rhs.rows && lhs.columns == rhs.columns,
+                 "Shape mismatch: [\(lhs.rows), \(lhs.columns)] vs [\(rhs.rows), \(rhs.columns)]")
+
+    var rowPointers = [0]
+    var columnIndices = [Int]()
+    var values = [Element]()
+
+    for row in 0..<lhs.rows {
+        let aStart = lhs.rowPointers[row], aEnd = lhs.rowPointers[row + 1]
+        let bStart = rhs.rowPointers[row], bEnd = rhs.rowPointers[row + 1]
+
+        var i = aStart, j = bStart
+        while i < aEnd && j < bEnd {
+            let colA = lhs.columnIndices[i]
+            let colB = rhs.columnIndices[j]
+
+            if colA < colB {
+                columnIndices.append(colA)
+                values.append(lhsOnly(lhs.values[i]))
+                i += 1
+            } else if colA > colB {
+                columnIndices.append(colB)
+                values.append(rhsOnly(rhs.values[j]))
+                j += 1
+            } else {
+                columnIndices.append(colA)
+                values.append(body(lhs.values[i], rhs.values[j]))
+                i += 1
+                j += 1
+            }
+        }
+
+        while i < aEnd {
+            columnIndices.append(lhs.columnIndices[i])
+            values.append(lhsOnly(lhs.values[i]))
+            i += 1
+        }
+
+        while j < bEnd {
+            columnIndices.append(rhs.columnIndices[j])
+            values.append(rhsOnly(rhs.values[j]))
+            j += 1
+        }
+
+        rowPointers.append(values.count)
+    }
+
+    return CSRMatrix(
+        rows: lhs.rows, columns: lhs.columns,
+        rowPointers: rowPointers, columnIndices: columnIndices, values: values
+    )
+}
+
+/// Row-by-row two-pointer intersection of two CSR matrices (matching column indices only).
+private func csrIntersect<Element>(
+    _ lhs: CSRMatrix<Element>,
+    _ rhs: CSRMatrix<Element>,
+    body: (Element, Element) -> Element
+) -> CSRMatrix<Element> {
+    precondition(lhs.rows == rhs.rows && lhs.columns == rhs.columns,
+                 "Shape mismatch: [\(lhs.rows), \(lhs.columns)] vs [\(rhs.rows), \(rhs.columns)]")
+
+    var rowPointers = [0]
+    var columnIndices = [Int]()
+    var values = [Element]()
+
+    for row in 0..<lhs.rows {
+        let aStart = lhs.rowPointers[row], aEnd = lhs.rowPointers[row + 1]
+        let bStart = rhs.rowPointers[row], bEnd = rhs.rowPointers[row + 1]
+
+        var i = aStart, j = bStart
+        while i < aEnd && j < bEnd {
+            let colA = lhs.columnIndices[i]
+            let colB = rhs.columnIndices[j]
+
+            if colA < colB {
+                i += 1
+            } else if colA > colB {
+                j += 1
+            } else {
+                columnIndices.append(colA)
+                values.append(body(lhs.values[i], rhs.values[j]))
+                i += 1
+                j += 1
+            }
+        }
+
+        rowPointers.append(values.count)
+    }
+
+    return CSRMatrix(
+        rows: lhs.rows, columns: lhs.columns,
+        rowPointers: rowPointers, columnIndices: columnIndices, values: values
+    )
+}
+
+// MARK: - CSRMatrix + CSRMatrix
+
+extension CSRMatrix where Element: AdditiveArithmetic {
+    public static func + (lhs: CSRMatrix, rhs: CSRMatrix) -> CSRMatrix {
+        csrMerge(lhs, rhs, body: +, lhsOnly: { $0 }, rhsOnly: { $0 })
+    }
+
+    public static func - (lhs: CSRMatrix, rhs: CSRMatrix) -> CSRMatrix {
+        csrMerge(lhs, rhs, body: -, lhsOnly: { $0 }, rhsOnly: { .zero - $0 })
+    }
+}
+
+extension CSRMatrix where Element: Numeric {
+    public static func * (lhs: CSRMatrix, rhs: CSRMatrix) -> CSRMatrix {
+        csrIntersect(lhs, rhs, body: *)
+    }
+}
+
+extension CSRMatrix where Element: SignedNumeric {
+    public static prefix func - (operand: CSRMatrix) -> CSRMatrix {
+        CSRMatrix(
+            rows: operand.rows, columns: operand.columns,
+            rowPointers: operand.rowPointers,
+            columnIndices: operand.columnIndices,
+            values: operand.values.map { -$0 }
+        )
+    }
+}
+
+// MARK: - CSRMatrix + Scalar / Scalar + CSRMatrix
+
+extension CSRMatrix where Element: Numeric {
+    public static func * (lhs: CSRMatrix, rhs: Element) -> CSRMatrix {
+        CSRMatrix(
+            rows: lhs.rows, columns: lhs.columns,
+            rowPointers: lhs.rowPointers,
+            columnIndices: lhs.columnIndices,
+            values: lhs.values.map { $0 * rhs }
+        )
+    }
+
+    public static func * (lhs: Element, rhs: CSRMatrix) -> CSRMatrix {
+        CSRMatrix(
+            rows: rhs.rows, columns: rhs.columns,
+            rowPointers: rhs.rowPointers,
+            columnIndices: rhs.columnIndices,
+            values: rhs.values.map { lhs * $0 }
+        )
+    }
+}
+
+extension CSRMatrix where Element: FloatingPoint {
+    public static func / (lhs: CSRMatrix, rhs: Element) -> CSRMatrix {
+        CSRMatrix(
+            rows: lhs.rows, columns: lhs.columns,
+            rowPointers: lhs.rowPointers,
+            columnIndices: lhs.columnIndices,
+            values: lhs.values.map { $0 / rhs }
+        )
+    }
+}
+
+// MARK: - Compound assignment
+
+extension CSRMatrix where Element: AdditiveArithmetic {
+    public static func += (lhs: inout CSRMatrix, rhs: CSRMatrix) {
+        lhs = lhs + rhs
+    }
+
+    public static func -= (lhs: inout CSRMatrix, rhs: CSRMatrix) {
+        lhs = lhs - rhs
+    }
+}
+
+extension CSRMatrix where Element: Numeric {
+    public static func *= (lhs: inout CSRMatrix, rhs: CSRMatrix) {
+        lhs = lhs * rhs
+    }
+}

--- a/Tests/SwiftMatrixTests/COOTensorArithmeticTests.swift
+++ b/Tests/SwiftMatrixTests/COOTensorArithmeticTests.swift
@@ -1,0 +1,304 @@
+import Testing
+@testable import SwiftMatrix
+
+struct COOTensorAdditionTests {
+    @Test func sameStructure() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [10, 20, 30]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [1, 2, 3]
+        )
+        let result = a + b
+        #expect(result.shape == [3, 3])
+        #expect(result.indices == [[0, 1, 2], [1, 2, 0]])
+        #expect(result.values == [11, 22, 33])
+    }
+
+    @Test func differentStructure() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 2], [0, 2]],
+            values: [10, 30]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[1], [1]],
+            values: [20]
+        )
+        let result = a + b
+        #expect(result.shape == [3, 3])
+        #expect(result.indices == [[0, 1, 2], [0, 1, 2]])
+        #expect(result.values == [10, 20, 30])
+    }
+
+    @Test func mixedStructure() {
+        // Some indices overlap, some don't
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [0, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[1, 2], [1, 2]],
+            values: [5, 30]
+        )
+        let result = a + b
+        #expect(result.shape == [3, 3])
+        #expect(result.indices == [[0, 1, 2], [0, 1, 2]])
+        #expect(result.values == [10, 25, 30])
+    }
+
+    @Test func emptyOperand() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        let b = COOTensor<Int>(shape: [3, 3])
+        let result = a + b
+        #expect(result == a)
+    }
+
+    @Test func bothEmpty() {
+        let a = COOTensor<Int>(shape: [3, 3])
+        let b = COOTensor<Int>(shape: [3, 3])
+        let result = a + b
+        #expect(result.nnz == 0)
+        #expect(result.shape == [3, 3])
+    }
+}
+
+struct COOTensorSubtractionTests {
+    @Test func sameStructure() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [10, 20, 30]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [1, 2, 3]
+        )
+        let result = a - b
+        #expect(result.indices == [[0, 1, 2], [1, 2, 0]])
+        #expect(result.values == [9, 18, 27])
+    }
+
+    @Test func cancellation() {
+        let a = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [5, 10]
+        )
+        // Subtracting same values produces stored zeros (no elimination)
+        let result = a - a
+        #expect(result.indices == [[0, 1], [0, 1]])
+        #expect(result.values == [0, 0])
+    }
+
+    @Test func differentStructure() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0], [0]],
+            values: [10]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[2], [2]],
+            values: [5]
+        )
+        let result = a - b
+        #expect(result.indices == [[0, 2], [0, 2]])
+        #expect(result.values == [10, -5])
+    }
+}
+
+struct COOTensorMultiplicationTests {
+    @Test func sameStructure() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [10, 20, 30]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1, 2], [1, 2, 0]],
+            values: [2, 3, 4]
+        )
+        let result = a * b
+        #expect(result.indices == [[0, 1, 2], [1, 2, 0]])
+        #expect(result.values == [20, 60, 120])
+    }
+
+    @Test func disjoint() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0], [0]],
+            values: [10]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[2], [2]],
+            values: [20]
+        )
+        let result = a * b
+        #expect(result.nnz == 0)
+    }
+
+    @Test func partialOverlap() {
+        let a = COOTensor(
+            shape: [3, 3],
+            indices: [[0, 1], [0, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [3, 3],
+            indices: [[1, 2], [1, 2]],
+            values: [3, 4]
+        )
+        let result = a * b
+        #expect(result.indices == [[1], [1]])
+        #expect(result.values == [60])
+    }
+}
+
+struct COOTensorScalarTests {
+    @Test func multiply() {
+        let a = COOTensor(
+            shape: [2, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        let result = a * 3
+        #expect(result.indices == [[0, 1], [1, 2]])
+        #expect(result.values == [30, 60])
+    }
+
+    @Test func multiplyCommutative() {
+        let a = COOTensor(
+            shape: [2, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10, 20]
+        )
+        #expect((a * 3).values == (3 * a).values)
+    }
+
+    @Test func divide() {
+        let a = COOTensor(
+            shape: [2, 3],
+            indices: [[0, 1], [1, 2]],
+            values: [10.0, 20.0]
+        )
+        let result = a / 2.0
+        #expect(result.values == [5.0, 10.0])
+    }
+}
+
+struct COOTensorNegationTests {
+    @Test func negation() {
+        let a = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [10, -20]
+        )
+        let result = -a
+        #expect(result.indices == [[0, 1], [0, 1]])
+        #expect(result.values == [-10, 20])
+    }
+
+    @Test func negationEmpty() {
+        let a = COOTensor<Int>(shape: [3, 3])
+        let result = -a
+        #expect(result.nnz == 0)
+    }
+}
+
+struct COOTensorCompoundAssignmentTests {
+    @Test func plusEquals() {
+        var a = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [1, 2]
+        )
+        a += b
+        #expect(a.values == [11, 22])
+    }
+
+    @Test func minusEquals() {
+        var a = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [1, 2]
+        )
+        a -= b
+        #expect(a.values == [9, 18])
+    }
+
+    @Test func timesEquals() {
+        var a = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [2, 2],
+            indices: [[0, 1], [0, 1]],
+            values: [2, 3]
+        )
+        a *= b
+        #expect(a.values == [20, 60])
+    }
+}
+
+struct COOTensorArithmeticRankTests {
+    @Test func rank1Addition() {
+        let a = COOTensor(
+            shape: [5],
+            indices: [[1, 3]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [5],
+            indices: [[0, 3]],
+            values: [5, 15]
+        )
+        let result = a + b
+        #expect(result.indices == [[0, 1, 3]])
+        #expect(result.values == [5, 10, 35])
+    }
+
+    @Test func rank3Multiplication() {
+        let a = COOTensor(
+            shape: [2, 3, 4],
+            indices: [[0, 1], [2, 0], [3, 1]],
+            values: [10, 20]
+        )
+        let b = COOTensor(
+            shape: [2, 3, 4],
+            indices: [[0, 1], [2, 1], [3, 0]],
+            values: [3, 4]
+        )
+        // Only (0,2,3) matches
+        let result = a * b
+        #expect(result.nnz == 1)
+        #expect(result.indices == [[0], [2], [3]])
+        #expect(result.values == [30])
+    }
+}

--- a/Tests/SwiftMatrixTests/CSRMatrixArithmeticTests.swift
+++ b/Tests/SwiftMatrixTests/CSRMatrixArithmeticTests.swift
@@ -1,0 +1,342 @@
+import Testing
+@testable import SwiftMatrix
+
+struct CSRMatrixAdditionTests {
+    @Test func sameStructure() {
+        // [[1, 0, 2], [0, 0, 3], [4, 0, 0]]
+        let a = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [1, 2, 3, 4]
+        )
+        let b = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [10, 20, 30, 40]
+        )
+        let result = a + b
+        #expect(result.rows == 3)
+        #expect(result.columns == 3)
+        #expect(result.rowPointers == [0, 2, 3, 4])
+        #expect(result.columnIndices == [0, 2, 2, 0])
+        #expect(result.values == [11, 22, 33, 44])
+    }
+
+    @Test func differentStructure() {
+        // a: [[1, 0], [0, 0]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [0],
+            values: [1]
+        )
+        // b: [[0, 0], [0, 2]]
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 0, 1],
+            columnIndices: [1],
+            values: [2]
+        )
+        let result = a + b
+        #expect(result.rowPointers == [0, 1, 2])
+        #expect(result.columnIndices == [0, 1])
+        #expect(result.values == [1, 2])
+    }
+
+    @Test func mixedStructure() {
+        // a: [[1, 0, 2], [0, 3, 0]]
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 2, 1],
+            values: [1, 2, 3]
+        )
+        // b: [[0, 4, 2], [5, 0, 0]]
+        let b = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [1, 2, 0],
+            values: [4, 2, 5]
+        )
+        let result = a + b
+        #expect(result.rowPointers == [0, 3, 5])
+        #expect(result.columnIndices == [0, 1, 2, 0, 1])
+        #expect(result.values == [1, 4, 4, 5, 3])
+    }
+
+    @Test func emptyOperand() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix<Int>(rows: 2, columns: 2)
+        let result = a + b
+        #expect(result == a)
+    }
+}
+
+struct CSRMatrixSubtractionTests {
+    @Test func sameStructure() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let result = a - b
+        #expect(result.values == [9, 18])
+    }
+
+    @Test func cancellation() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [5, 10]
+        )
+        let result = a - a
+        #expect(result.columnIndices == [0, 1])
+        #expect(result.values == [0, 0])
+    }
+
+    @Test func differentStructure() {
+        // a: [[10, 0], [0, 0]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [0],
+            values: [10]
+        )
+        // b: [[0, 0], [0, 5]]
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 0, 1],
+            columnIndices: [1],
+            values: [5]
+        )
+        let result = a - b
+        #expect(result.rowPointers == [0, 1, 2])
+        #expect(result.columnIndices == [0, 1])
+        #expect(result.values == [10, -5])
+    }
+}
+
+struct CSRMatrixMultiplicationTests {
+    @Test func sameStructure() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [2, 3]
+        )
+        let result = a * b
+        #expect(result.values == [20, 60])
+    }
+
+    @Test func disjoint() {
+        // a: [[1, 0], [0, 0]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [0],
+            values: [1]
+        )
+        // b: [[0, 2], [0, 0]]
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [1],
+            values: [2]
+        )
+        let result = a * b
+        #expect(result.nnz == 0)
+    }
+
+    @Test func partialOverlap() {
+        // a: [[1, 2], [3, 0]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [1, 2, 3]
+        )
+        // b: [[0, 4], [0, 5]]
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [1],
+            values: [4]
+        )
+        let result = a * b
+        #expect(result.rowPointers == [0, 1, 1])
+        #expect(result.columnIndices == [1])
+        #expect(result.values == [8])
+    }
+}
+
+struct CSRMatrixScalarTests {
+    @Test func multiply() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let result = a * 3
+        #expect(result.values == [30, 60])
+        #expect(result.columnIndices == [0, 1])
+    }
+
+    @Test func multiplyCommutative() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        #expect((a * 3).values == (3 * a).values)
+    }
+
+    @Test func divide() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10.0, 20.0]
+        )
+        let result = a / 2.0
+        #expect(result.values == [5.0, 10.0])
+    }
+}
+
+struct CSRMatrixNegationTests {
+    @Test func negation() {
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, -20]
+        )
+        let result = -a
+        #expect(result.values == [-10, 20])
+        #expect(result.columnIndices == [0, 1])
+    }
+
+    @Test func negationEmpty() {
+        let a = CSRMatrix<Int>(rows: 2, columns: 2)
+        let result = -a
+        #expect(result.nnz == 0)
+    }
+}
+
+struct CSRMatrixCompoundAssignmentTests {
+    @Test func plusEquals() {
+        var a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        a += b
+        #expect(a.values == [11, 22])
+    }
+
+    @Test func minusEquals() {
+        var a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        a -= b
+        #expect(a.values == [9, 18])
+    }
+
+    @Test func timesEquals() {
+        var a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [2, 3]
+        )
+        a *= b
+        #expect(a.values == [20, 60])
+    }
+}
+
+struct CSRMatrixEmptyRowTests {
+    @Test func addWithEmptyRows() {
+        // Row 1 is empty in both
+        let a = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 0, 0, 1],
+            columnIndices: [0],
+            values: [5]
+        )
+        let result = a + b
+        #expect(result.rowPointers == [0, 1, 1, 3])
+        #expect(result.columnIndices == [0, 0, 1])
+        #expect(result.values == [10, 5, 20])
+    }
+
+    @Test func multiplyWithEmptyRows() {
+        // a has entries in rows 0 and 2; b has entries in rows 1 and 2
+        let a = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 1, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let b = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 0, 1, 2],
+            columnIndices: [0, 1],
+            values: [5, 3]
+        )
+        // Only row 2 has overlap (col 1)
+        let result = a * b
+        #expect(result.rowPointers == [0, 0, 0, 1])
+        #expect(result.columnIndices == [1])
+        #expect(result.values == [60])
+    }
+}


### PR DESCRIPTION
## Summary

- Add element-wise `+`, `-`, `*`, scalar `*`, scalar `/`, negation, and compound assignment for both `COOTensor` and `CSRMatrix`
- Uses O(nnz_a + nnz_b) two-pointer merge/intersection on sorted entries
- Follows the same operator pattern and constraint groupings as `Tensor+Arithmetic.swift`

Closes #33

## Test plan

- [x] 24 COO arithmetic tests (addition, subtraction, multiplication, scalar, negation, compound, multi-rank)
- [x] 22 CSR arithmetic tests (addition, subtraction, multiplication, scalar, negation, compound, empty rows)
- [x] Full test suite passes (200 tests)
- [x] `swift build && swift test` green