### PR TITLE
Add sparse reductions for COOTensor and CSRMatrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,13 +57,11 @@ Both are separate types from `Tensor` -- conversions via `init(from:)` and `toTe
 
 Element-wise `+`, `-`, `*`, scalar `*`, scalar `/`, negation, and compound assignment (`+=`, `-=`, `*=`). Uses two-pointer merge (addition/subtraction) and intersection (multiplication) on sorted entries for O(nnz_a + nnz_b) performance. No `sparse + scalar` (densifies) or `sparse / sparse` (divide by implicit zero).
 
-### Sparse Linear Algebra
+### Sparse Reductions
 
-`CSRMatrix.matvec(_:_:)` (SpMV): CSR [m,n] * dense vector [n] -> dense [m]. Row-iterate CSR, accumulate `value * vector[col]`.
+`COOTensor`: `sum()`, `mean()`, `dot(_:_:)`. Sum/mean operate on stored values in O(nnz); mean divides by total `count` (not nnz). Dot uses two-pointer intersection on sorted rank-1 indices.
 
-`CSRMatrix.matmul(_:_:)` (SpMM, sparse * dense): CSR [m,k] * Tensor [k,n] -> Tensor [m,n]. Scatter approach: for each nonzero A[row,col], scatter into result row.
-
-`CSRMatrix.matmul(_:_:)` (SpGEMM, sparse * sparse): CSR [m,k] * CSR [k,n] -> CSR [m,n]. Row-wise dense accumulator with boolean marker array. Keeps explicit zeros from cancellation.
+`CSRMatrix`: `sum()`, `sum(axis:)`, `mean()`, `mean(axis:)`. Axis 0 (column sums) accumulates into column buckets; axis 1 (row sums) iterates each row's range. All O(nnz). No axis reductions for COO (lacks row structure).
 
 ### Performance
 

--- a/Sources/SwiftMatrix/COOTensor+Reductions.swift
+++ b/Sources/SwiftMatrix/COOTensor+Reductions.swift
@@ -1,0 +1,72 @@
+/// Reductions for ``COOTensor``.
+
+extension COOTensor where Element: AdditiveArithmetic {
+    /// Returns the sum of all stored (nonzero) elements. O(nnz).
+    ///
+    /// Implicit zeros do not affect the sum, so this is equivalent to summing
+    /// the full dense tensor.
+    ///
+    /// ```swift
+    /// let coo = COOTensor(shape: [4], indices: [[0, 2, 3]], values: [1, 2, 3])
+    /// coo.sum()  // 6
+    /// ```
+    public func sum() -> Element {
+        values.reduce(.zero, +)
+    }
+}
+
+extension COOTensor where Element: FloatingPoint {
+    /// Returns the arithmetic mean over all logical elements. O(nnz).
+    ///
+    /// The divisor is ``count`` (the product of shape dimensions), not ``nnz``,
+    /// so implicit zeros are included in the average.
+    ///
+    /// ```swift
+    /// let coo = COOTensor(shape: [4], indices: [[0, 1, 2]], values: [1.0, 2.0, 3.0])
+    /// coo.mean()  // 1.5  (sum=6.0, count=4)
+    /// ```
+    public func mean() -> Element {
+        sum() / Element(count)
+    }
+}
+
+extension COOTensor where Element: Numeric {
+    /// Computes the dot product (inner product) of two rank-1 sparse tensors. O(nnz_a + nnz_b).
+    ///
+    /// Uses two-pointer intersection on sorted indices, accumulating products only
+    /// where both tensors have stored entries.
+    ///
+    /// ```swift
+    /// let a = COOTensor(shape: [5], indices: [[0, 2, 4]], values: [1, 3, 5])
+    /// let b = COOTensor(shape: [5], indices: [[1, 2, 3]], values: [2, 4, 6])
+    /// COOTensor.dot(a, b)  // 12  (only index 2 overlaps: 3*4)
+    /// ```
+    ///
+    /// - Precondition: Both tensors are rank-1 with the same shape.
+    /// - Returns: The sum of element-wise products at matching indices.
+    public static func dot(_ lhs: COOTensor, _ rhs: COOTensor) -> Element {
+        precondition(lhs.rank == 1 && rhs.rank == 1,
+                     "dot requires rank-1 tensors, got ranks \(lhs.rank) and \(rhs.rank)")
+        precondition(lhs.shape == rhs.shape,
+                     "Shape mismatch: \(lhs.shape) vs \(rhs.shape)")
+
+        var result: Element = .zero
+        var i = 0, j = 0
+        let lhsIdx = lhs.indices[0]
+        let rhsIdx = rhs.indices[0]
+
+        while i < lhs.nnz && j < rhs.nnz {
+            if lhsIdx[i] < rhsIdx[j] {
+                i += 1
+            } else if lhsIdx[i] > rhsIdx[j] {
+                j += 1
+            } else {
+                result += lhs.values[i] * rhs.values[j]
+                i += 1
+                j += 1
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/SwiftMatrix/CSRMatrix+Reductions.swift
+++ b/Sources/SwiftMatrix/CSRMatrix+Reductions.swift
@@ -1,0 +1,89 @@
+/// Reductions for ``CSRMatrix``.
+
+// MARK: - Sum
+
+extension CSRMatrix where Element: AdditiveArithmetic {
+    /// Returns the sum of all stored (nonzero) elements. O(nnz).
+    ///
+    /// Implicit zeros do not affect the sum, so this is equivalent to summing
+    /// the full dense matrix.
+    ///
+    /// ```swift
+    /// let csr = CSRMatrix(rows: 2, columns: 2,
+    ///     rowPointers: [0, 1, 2], columnIndices: [0, 1], values: [10, 20])
+    /// csr.sum()  // 30
+    /// ```
+    public func sum() -> Element {
+        values.reduce(.zero, +)
+    }
+
+    /// Returns a tensor with one axis collapsed by summation. O(nnz).
+    ///
+    /// - `axis: 0` produces column sums with shape `[columns]`.
+    /// - `axis: 1` produces row sums with shape `[rows]`.
+    ///
+    /// ```swift
+    /// // [[1, 0, 2], [0, 3, 0]]
+    /// csr.sum(axis: 0)  // [1, 3, 2]  (column sums)
+    /// csr.sum(axis: 1)  // [3, 3]     (row sums)
+    /// ```
+    ///
+    /// - Parameter axis: The axis to sum along (0 or 1).
+    /// - Precondition: `axis` is 0 or 1.
+    public func sum(axis: Int) -> Tensor<Element> {
+        precondition(axis == 0 || axis == 1,
+                     "Axis \(axis) out of range for rank-2 CSR matrix")
+
+        if axis == 1 {
+            // Row sums: sum entries in each row's range
+            var result = [Element]()
+            result.reserveCapacity(rows)
+            for row in 0..<rows {
+                var total: Element = .zero
+                for idx in rowPointers[row]..<rowPointers[row + 1] {
+                    total = total + values[idx]
+                }
+                result.append(total)
+            }
+            return Tensor(shape: [rows], elements: result)
+        } else {
+            // Column sums: accumulate into column buckets
+            var result = Array(repeating: Element.zero, count: columns)
+            for idx in 0..<nnz {
+                result[columnIndices[idx]] = result[columnIndices[idx]] + values[idx]
+            }
+            return Tensor(shape: [columns], elements: result)
+        }
+    }
+}
+
+// MARK: - Mean
+
+extension CSRMatrix where Element: FloatingPoint {
+    /// Returns the arithmetic mean over all logical elements. O(nnz).
+    ///
+    /// The divisor is `rows * columns` (not ``nnz``), so implicit zeros are
+    /// included in the average.
+    ///
+    /// ```swift
+    /// // [[1, 0], [0, 3]] -> sum=4, count=4 -> mean=1.0
+    /// csr.mean()  // 1.0
+    /// ```
+    public func mean() -> Element {
+        sum() / Element(count)
+    }
+
+    /// Returns a tensor with one axis collapsed by averaging. O(nnz).
+    ///
+    /// Divides `sum(axis:)` by the size of the collapsed axis.
+    /// - `axis: 0` divides by `rows` (column means).
+    /// - `axis: 1` divides by `columns` (row means).
+    ///
+    /// - Parameter axis: The axis to average along (0 or 1).
+    /// - Precondition: `axis` is 0 or 1.
+    public func mean(axis: Int) -> Tensor<Element> {
+        let s = sum(axis: axis)
+        let divisor = axis == 0 ? Element(rows) : Element(columns)
+        return Tensor(shape: s.shape, elements: s.map { $0 / divisor })
+    }
+}

--- a/Tests/SwiftMatrixTests/COOTensorReductionTests.swift
+++ b/Tests/SwiftMatrixTests/COOTensorReductionTests.swift
@@ -1,0 +1,159 @@
+import Testing
+@testable import SwiftMatrix
+
+struct COOTensorSumTests {
+    @Test func basicSum() {
+        let coo = COOTensor(
+            shape: [3],
+            indices: [[0, 1, 2]],
+            values: [10, 20, 30]
+        )
+        #expect(coo.sum() == 60)
+    }
+
+    @Test func emptyTensor() {
+        let coo = COOTensor<Int>(shape: [5])
+        #expect(coo.sum() == 0)
+    }
+
+    @Test func rank3() {
+        // 2x2x2 with 3 nonzero entries
+        let coo = COOTensor(
+            shape: [2, 2, 2],
+            indices: [[0, 0, 1], [0, 1, 0], [1, 0, 1]],
+            values: [1, 2, 3]
+        )
+        #expect(coo.sum() == 6)
+    }
+
+    @Test func matchesDense() {
+        let coo = COOTensor(
+            shape: [3, 4],
+            indices: [[0, 1, 2, 2], [1, 2, 0, 3]],
+            values: [10, 20, 30, 40]
+        )
+        #expect(coo.sum() == coo.toTensor().sum())
+    }
+}
+
+struct COOTensorMeanTests {
+    @Test func basicMean() {
+        // shape [4], values at 0,1,2 -> sum=6.0, count=4 -> mean=1.5
+        let coo = COOTensor(
+            shape: [4],
+            indices: [[0, 1, 2]],
+            values: [1.0, 2.0, 3.0]
+        )
+        #expect(coo.mean() == 1.5)
+    }
+
+    @Test func emptyTensor() {
+        let coo = COOTensor<Double>(shape: [4])
+        #expect(coo.mean() == 0.0)
+    }
+
+    @Test func matchesDense() {
+        let coo = COOTensor(
+            shape: [2, 3],
+            indices: [[0, 1, 1], [0, 1, 2]],
+            values: [6.0, 3.0, 9.0]
+        )
+        #expect(coo.mean() == coo.toTensor().mean())
+    }
+
+    @Test func allNonzero() {
+        // Every element is nonzero
+        let coo = COOTensor(
+            shape: [3],
+            indices: [[0, 1, 2]],
+            values: [2.0, 4.0, 6.0]
+        )
+        #expect(coo.mean() == 4.0)
+    }
+}
+
+struct COOTensorDotProductTests {
+    @Test func basicDot() {
+        let a = COOTensor(
+            shape: [4],
+            indices: [[0, 1, 3]],
+            values: [1, 2, 3]
+        )
+        let b = COOTensor(
+            shape: [4],
+            indices: [[0, 1, 2]],
+            values: [10, 20, 30]
+        )
+        // overlap at indices 0,1: 1*10 + 2*20 = 50
+        #expect(COOTensor.dot(a, b) == 50)
+    }
+
+    @Test func disjointIndices() {
+        let a = COOTensor(
+            shape: [4],
+            indices: [[0, 1]],
+            values: [1, 2]
+        )
+        let b = COOTensor(
+            shape: [4],
+            indices: [[2, 3]],
+            values: [3, 4]
+        )
+        #expect(COOTensor.dot(a, b) == 0)
+    }
+
+    @Test func fullOverlap() {
+        let a = COOTensor(
+            shape: [3],
+            indices: [[0, 1, 2]],
+            values: [1, 2, 3]
+        )
+        let b = COOTensor(
+            shape: [3],
+            indices: [[0, 1, 2]],
+            values: [4, 5, 6]
+        )
+        // 1*4 + 2*5 + 3*6 = 32
+        #expect(COOTensor.dot(a, b) == 32)
+    }
+
+    @Test func partialOverlap() {
+        // a has entries at 0,2,4; b has entries at 1,2,3
+        let a = COOTensor(
+            shape: [5],
+            indices: [[0, 2, 4]],
+            values: [10, 20, 30]
+        )
+        let b = COOTensor(
+            shape: [5],
+            indices: [[1, 2, 3]],
+            values: [5, 6, 7]
+        )
+        // overlap at index 2: 20*6 = 120
+        #expect(COOTensor.dot(a, b) == 120)
+    }
+
+    @Test func emptyOperands() {
+        let a = COOTensor<Int>(shape: [5])
+        let b = COOTensor(
+            shape: [5],
+            indices: [[0, 2]],
+            values: [10, 20]
+        )
+        #expect(COOTensor.dot(a, b) == 0)
+    }
+
+    @Test func matchesDense() {
+        let a = COOTensor(
+            shape: [5],
+            indices: [[0, 2, 4]],
+            values: [1, 3, 5]
+        )
+        let b = COOTensor(
+            shape: [5],
+            indices: [[1, 2, 3]],
+            values: [2, 4, 6]
+        )
+        #expect(COOTensor.dot(a, b) == Tensor.dot(a.toTensor(), b.toTensor()))
+    }
+}

--- a/Tests/SwiftMatrixTests/CSRMatrixReductionTests.swift
+++ b/Tests/SwiftMatrixTests/CSRMatrixReductionTests.swift
@@ -1,0 +1,224 @@
+import Testing
+@testable import SwiftMatrix
+
+struct CSRMatrixSumTests {
+    @Test func basicSum() {
+        // [[1, 0, 2], [0, 0, 3], [4, 0, 0]]
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 2, 2, 0],
+            values: [1, 2, 3, 4]
+        )
+        #expect(csr.sum() == 10)
+    }
+
+    @Test func emptyMatrix() {
+        let csr = CSRMatrix<Int>(rows: 3, columns: 3)
+        #expect(csr.sum() == 0)
+    }
+
+    @Test func matchesDense() {
+        let csr = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 2, 1],
+            values: [10, 20, 30]
+        )
+        #expect(csr.sum() == csr.toTensor().sum())
+    }
+}
+
+struct CSRMatrixSumAxisTests {
+    @Test func sumAxis0() {
+        // [[1, 0, 2], [0, 3, 0], [4, 0, 5]]
+        // column sums: [5, 3, 7]
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 5],
+            columnIndices: [0, 2, 1, 0, 2],
+            values: [1, 2, 3, 4, 5]
+        )
+        let result = csr.sum(axis: 0)
+        #expect(result.shape == [3])
+        #expect(Array(result) == [5, 3, 7])
+    }
+
+    @Test func sumAxis1() {
+        // [[1, 0, 2], [0, 3, 0], [4, 0, 5]]
+        // row sums: [3, 3, 9]
+        let csr = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 5],
+            columnIndices: [0, 2, 1, 0, 2],
+            values: [1, 2, 3, 4, 5]
+        )
+        let result = csr.sum(axis: 1)
+        #expect(result.shape == [3])
+        #expect(Array(result) == [3, 3, 9])
+    }
+
+    @Test func emptyMatrix() {
+        let csr = CSRMatrix<Int>(rows: 2, columns: 3)
+        let axis0 = csr.sum(axis: 0)
+        #expect(axis0.shape == [3])
+        #expect(Array(axis0) == [0, 0, 0])
+
+        let axis1 = csr.sum(axis: 1)
+        #expect(axis1.shape == [2])
+        #expect(Array(axis1) == [0, 0])
+    }
+
+    @Test func emptyRows() {
+        // Row 1 is empty: [[1, 2], [0, 0], [3, 0]]
+        let csr = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 2, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [1, 2, 3]
+        )
+        let axis1 = csr.sum(axis: 1)
+        #expect(Array(axis1) == [3, 0, 3])
+    }
+
+    @Test func matchesDenseAxis0() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 4,
+            rowPointers: [0, 2, 4, 5],
+            columnIndices: [1, 3, 0, 2, 1],
+            values: [10, 20, 30, 40, 50]
+        )
+        let expected = csr.toTensor().sum(axis: 0)
+        let result = csr.sum(axis: 0)
+        #expect(Array(result) == Array(expected))
+    }
+
+    @Test func matchesDenseAxis1() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 4,
+            rowPointers: [0, 2, 4, 5],
+            columnIndices: [1, 3, 0, 2, 1],
+            values: [10, 20, 30, 40, 50]
+        )
+        let expected = csr.toTensor().sum(axis: 1)
+        let result = csr.sum(axis: 1)
+        #expect(Array(result) == Array(expected))
+    }
+
+    @Test func singleRow() {
+        let csr = CSRMatrix(
+            rows: 1, columns: 4,
+            rowPointers: [0, 2],
+            columnIndices: [1, 3],
+            values: [5, 10]
+        )
+        let axis0 = csr.sum(axis: 0)
+        #expect(Array(axis0) == [0, 5, 0, 10])
+
+        let axis1 = csr.sum(axis: 1)
+        #expect(Array(axis1) == [15])
+    }
+
+    @Test func singleColumn() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 1,
+            rowPointers: [0, 1, 1, 1],
+            columnIndices: [0],
+            values: [7]
+        )
+        let axis0 = csr.sum(axis: 0)
+        #expect(Array(axis0) == [7])
+
+        let axis1 = csr.sum(axis: 1)
+        #expect(Array(axis1) == [7, 0, 0])
+    }
+}
+
+struct CSRMatrixMeanTests {
+    @Test func basicMean() {
+        // [[1, 0], [0, 3]] -> sum=4, count=4 -> mean=1.0
+        let csr = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1.0, 3.0]
+        )
+        #expect(csr.mean() == 1.0)
+    }
+
+    @Test func emptyMatrix() {
+        let csr = CSRMatrix<Double>(rows: 2, columns: 2)
+        #expect(csr.mean() == 0.0)
+    }
+
+    @Test func matchesDense() {
+        let csr = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 2, 1],
+            values: [6.0, 3.0, 9.0]
+        )
+        #expect(csr.mean() == csr.toTensor().mean())
+    }
+}
+
+struct CSRMatrixMeanAxisTests {
+    @Test func meanAxis0() {
+        // [[2, 0], [0, 4]] -> col means: [1.0, 2.0]
+        let csr = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [2.0, 4.0]
+        )
+        let result = csr.mean(axis: 0)
+        #expect(result.shape == [2])
+        #expect(Array(result) == [1.0, 2.0])
+    }
+
+    @Test func meanAxis1() {
+        // [[2, 0], [0, 4]] -> row means: [1.0, 2.0]
+        let csr = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [2.0, 4.0]
+        )
+        let result = csr.mean(axis: 1)
+        #expect(result.shape == [2])
+        #expect(Array(result) == [1.0, 2.0])
+    }
+
+    @Test func matchesDenseAxis0() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [3.0, 6.0, 9.0]
+        )
+        let expected = csr.toTensor().mean(axis: 0)
+        let result = csr.mean(axis: 0)
+        #expect(Array(result) == Array(expected))
+    }
+
+    @Test func matchesDenseAxis1() {
+        let csr = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [3.0, 6.0, 9.0]
+        )
+        let expected = csr.toTensor().mean(axis: 1)
+        let result = csr.mean(axis: 1)
+        #expect(Array(result) == Array(expected))
+    }
+
+    @Test func emptyMatrix() {
+        let csr = CSRMatrix<Double>(rows: 2, columns: 3)
+        let axis0 = csr.mean(axis: 0)
+        #expect(Array(axis0) == [0.0, 0.0, 0.0])
+
+        let axis1 = csr.mean(axis: 1)
+        #expect(Array(axis1) == [0.0, 0.0])
+    }
+}


### PR DESCRIPTION
## Summary

- Add `sum()`, `mean()`, and `dot(_:_:)` for `COOTensor`
- Add `sum()`, `sum(axis:)`, `mean()`, `mean(axis:)` for `CSRMatrix`
- All operations are O(nnz); dot uses two-pointer intersection on sorted indices

Closes #38

## Test plan

- [x] COOTensor sum: basic, empty, rank-3, matches dense
- [x] COOTensor mean: basic, empty, matches dense, all nonzero
- [x] COOTensor dot: basic, disjoint, full/partial overlap, empty, matches dense
- [x] CSRMatrix sum: basic, empty, matches dense
- [x] CSRMatrix sum(axis:): axis 0/1, empty, empty rows, single row/column, matches dense
- [x] CSRMatrix mean: basic, empty, matches dense
- [x] CSRMatrix mean(axis:): axis 0/1, empty, matches dense