### PR TITLE
Add SpMV, SpMM, and SpGEMM for CSRMatrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@ Both are separate types from `Tensor` -- conversions via `init(from:)` and `toTe
 
 Element-wise `+`, `-`, `*`, scalar `*`, scalar `/`, negation, and compound assignment (`+=`, `-=`, `*=`). Uses two-pointer merge (addition/subtraction) and intersection (multiplication) on sorted entries for O(nnz_a + nnz_b) performance. No `sparse + scalar` (densifies) or `sparse / sparse` (divide by implicit zero).
 
+### Sparse Linear Algebra
+
+`CSRMatrix.matvec(_:_:)` (SpMV): CSR [m,n] * dense vector [n] -> dense [m]. Row-iterate CSR, accumulate `value * vector[col]`.
+
+`CSRMatrix.matmul(_:_:)` (SpMM, sparse * dense): CSR [m,k] * Tensor [k,n] -> Tensor [m,n]. Scatter approach: for each nonzero A[row,col], scatter into result row.
+
+`CSRMatrix.matmul(_:_:)` (SpGEMM, sparse * sparse): CSR [m,k] * CSR [k,n] -> CSR [m,n]. Row-wise dense accumulator with boolean marker array. Keeps explicit zeros from cancellation.
+
 ### Performance
 
 - `logicalStrides: [Int]` cached at init time (avoids per-access `computeStrides` allocations)

--- a/Sources/SwiftMatrix/CSRMatrix+LinearAlgebra.swift
+++ b/Sources/SwiftMatrix/CSRMatrix+LinearAlgebra.swift
@@ -1,0 +1,153 @@
+/// Sparse matrix-vector and matrix-matrix multiplication for ``CSRMatrix``.
+
+extension CSRMatrix where Element: Numeric {
+    /// Sparse matrix-vector multiplication (SpMV): CSR [m, n] * dense vector [n] -> dense [m].
+    ///
+    /// For each row of the sparse matrix, accumulates `value * vector[col]` over stored entries.
+    ///
+    /// ```swift
+    /// let a = CSRMatrix(rows: 2, columns: 3,
+    ///     rowPointers: [0, 2, 3], columnIndices: [0, 2, 1], values: [1, 2, 3])
+    /// let x = Tensor(shape: [3], elements: [4, 5, 6])
+    /// CSRMatrix.matvec(a, x)  // [16, 15]  (1*4+2*6, 3*5)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - matrix: A sparse matrix with shape [m, n].
+    ///   - vector: A dense rank-1 tensor with shape [n].
+    /// - Precondition: `vector` is rank-1 with length equal to `matrix.columns`.
+    /// - Returns: A dense rank-1 tensor with shape [m].
+    public static func matvec(_ matrix: CSRMatrix, _ vector: Tensor<Element>) -> Tensor<Element> {
+        precondition(vector.rank == 1,
+                     "matvec requires a rank-1 vector, got rank \(vector.rank)")
+        precondition(vector.shape[0] == matrix.columns,
+                     "Dimension mismatch: matrix has \(matrix.columns) columns, vector has \(vector.shape[0]) elements")
+
+        let m = matrix.rows
+        var result = Array(repeating: Element.zero, count: m)
+
+        for row in 0..<m {
+            var sum: Element = .zero
+            for idx in matrix.rowPointers[row]..<matrix.rowPointers[row + 1] {
+                sum += matrix.values[idx] * vector[matrix.columnIndices[idx]]
+            }
+            result[row] = sum
+        }
+
+        return Tensor(shape: [m], elements: result)
+    }
+
+    /// Sparse-dense matrix multiplication (SpMM): CSR [m, k] * Tensor [k, n] -> Tensor [m, n].
+    ///
+    /// For each nonzero entry `A[row, col]`, scatters `A[row, col] * B[col, j]` across all
+    /// columns `j` of the result row.
+    ///
+    /// ```swift
+    /// let a = CSRMatrix(rows: 2, columns: 2,
+    ///     rowPointers: [0, 1, 2], columnIndices: [0, 1], values: [1, 2])
+    /// let b = Tensor([[3, 4], [5, 6]])
+    /// CSRMatrix.matmul(a, b)  // [[3, 4], [10, 12]]
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - lhs: A sparse matrix with shape [m, k].
+    ///   - rhs: A dense rank-2 tensor with shape [k, n].
+    /// - Precondition: `rhs` is rank-2 with `rhs.shape[0] == lhs.columns`.
+    /// - Returns: A dense rank-2 tensor with shape [m, n].
+    public static func matmul(_ lhs: CSRMatrix, _ rhs: Tensor<Element>) -> Tensor<Element> {
+        precondition(rhs.rank == 2,
+                     "matmul requires a rank-2 tensor, got rank \(rhs.rank)")
+        let k = lhs.columns
+        let n = rhs.shape[1]
+        precondition(rhs.shape[0] == k,
+                     "Dimension mismatch: matrix has \(k) columns, rhs has \(rhs.shape[0]) rows")
+
+        let m = lhs.rows
+        var result = Array(repeating: Element.zero, count: m * n)
+
+        for row in 0..<m {
+            for idx in lhs.rowPointers[row]..<lhs.rowPointers[row + 1] {
+                let col = lhs.columnIndices[idx]
+                let aVal = lhs.values[idx]
+                for j in 0..<n {
+                    result[row * n + j] += aVal * rhs[col, j]
+                }
+            }
+        }
+
+        return Tensor(shape: [m, n], elements: result)
+    }
+
+    /// Sparse-sparse matrix multiplication (SpGEMM): CSR [m, k] * CSR [k, n] -> CSR [m, n].
+    ///
+    /// Uses a row-wise dense accumulator with a boolean marker array to track touched
+    /// columns. Column indices are sorted before emission to maintain the CSR invariant.
+    /// Explicit zeros from cancellation are kept, consistent with existing sparse arithmetic.
+    ///
+    /// ```swift
+    /// let a = CSRMatrix(rows: 2, columns: 2,
+    ///     rowPointers: [0, 1, 2], columnIndices: [0, 1], values: [1, 2])
+    /// let b = CSRMatrix(rows: 2, columns: 2,
+    ///     rowPointers: [0, 1, 2], columnIndices: [0, 1], values: [3, 4])
+    /// CSRMatrix.matmul(a, b)  // diag([3, 8])
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - lhs: A sparse matrix with shape [m, k].
+    ///   - rhs: A sparse matrix with shape [k, n].
+    /// - Precondition: `lhs.columns == rhs.rows`.
+    /// - Returns: A sparse CSR matrix with shape [m, n].
+    public static func matmul(_ lhs: CSRMatrix, _ rhs: CSRMatrix) -> CSRMatrix {
+        let k = lhs.columns
+        precondition(k == rhs.rows,
+                     "Dimension mismatch: lhs has \(k) columns, rhs has \(rhs.rows) rows")
+
+        let m = lhs.rows
+        let n = rhs.columns
+
+        var resultRowPointers = [Int]()
+        resultRowPointers.reserveCapacity(m + 1)
+        resultRowPointers.append(0)
+        var resultColumnIndices = [Int]()
+        var resultValues = [Element]()
+
+        // Reusable dense accumulator and marker array
+        var accumulator = Array(repeating: Element.zero, count: n)
+        var marker = Array(repeating: false, count: n)
+        var touchedColumns = [Int]()
+
+        for row in 0..<m {
+            touchedColumns.removeAll(keepingCapacity: true)
+
+            for idx in lhs.rowPointers[row]..<lhs.rowPointers[row + 1] {
+                let kCol = lhs.columnIndices[idx]
+                let aVal = lhs.values[idx]
+
+                for jIdx in rhs.rowPointers[kCol]..<rhs.rowPointers[kCol + 1] {
+                    let j = rhs.columnIndices[jIdx]
+                    if !marker[j] {
+                        marker[j] = true
+                        touchedColumns.append(j)
+                    }
+                    accumulator[j] += aVal * rhs.values[jIdx]
+                }
+            }
+
+            // Sort columns to maintain CSR invariant
+            touchedColumns.sort()
+
+            // Emit nonzeros and reset
+            for j in touchedColumns {
+                resultColumnIndices.append(j)
+                resultValues.append(accumulator[j])
+                accumulator[j] = .zero
+                marker[j] = false
+            }
+
+            resultRowPointers.append(resultColumnIndices.count)
+        }
+
+        return CSRMatrix(rows: m, columns: n, rowPointers: resultRowPointers,
+                         columnIndices: resultColumnIndices, values: resultValues)
+    }
+}

--- a/Tests/SwiftMatrixTests/CSRMatrixLinearAlgebraTests.swift
+++ b/Tests/SwiftMatrixTests/CSRMatrixLinearAlgebraTests.swift
@@ -1,0 +1,300 @@
+import Testing
+@testable import SwiftMatrix
+
+struct CSRMatrixMatvecTests {
+    @Test func basic() {
+        // [[1, 0, 2], [0, 3, 0], [4, 0, 5]]
+        let a = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 2, 3, 5],
+            columnIndices: [0, 2, 1, 0, 2],
+            values: [1, 2, 3, 4, 5]
+        )
+        let x = Tensor(shape: [3], elements: [1, 2, 3])
+        // row 0: 1*1 + 2*3 = 7
+        // row 1: 3*2 = 6
+        // row 2: 4*1 + 5*3 = 19
+        let result = CSRMatrix.matvec(a, x)
+        #expect(result.shape == [3])
+        #expect(Array(result) == [7, 6, 19])
+    }
+
+    @Test func identityMatrix() {
+        let eye = CSRMatrix(
+            rows: 3, columns: 3,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 2],
+            values: [1, 1, 1]
+        )
+        let x = Tensor(shape: [3], elements: [10, 20, 30])
+        let result = CSRMatrix.matvec(eye, x)
+        #expect(Array(result) == [10, 20, 30])
+    }
+
+    @Test func emptyMatrix() {
+        let a = CSRMatrix<Int>(rows: 2, columns: 3)
+        let x = Tensor(shape: [3], elements: [1, 2, 3])
+        let result = CSRMatrix.matvec(a, x)
+        #expect(Array(result) == [0, 0])
+    }
+
+    @Test func emptyRows() {
+        // Row 1 is empty: [[1, 2], [0, 0], [3, 0]]
+        let a = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 2, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [1, 2, 3]
+        )
+        let x = Tensor(shape: [2], elements: [10, 20])
+        let result = CSRMatrix.matvec(a, x)
+        #expect(Array(result) == [50, 0, 30])
+    }
+
+    @Test func singleRow() {
+        let a = CSRMatrix(
+            rows: 1, columns: 3,
+            rowPointers: [0, 2],
+            columnIndices: [0, 2],
+            values: [3, 5]
+        )
+        let x = Tensor(shape: [3], elements: [1, 2, 3])
+        // 3*1 + 5*3 = 18
+        let result = CSRMatrix.matvec(a, x)
+        #expect(Array(result) == [18])
+    }
+
+    @Test func matchesDense() {
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 2, 1],
+            values: [1, 2, 3]
+        )
+        let x = Tensor(shape: [3], elements: [4, 5, 6])
+        let sparse = CSRMatrix.matvec(a, x)
+        // Dense matmul: reshape x to [3,1], matmul, flatten
+        let dense = Tensor.matmul(
+            a.toTensor(),
+            Tensor(shape: [3, 1], elements: Array(x))
+        )
+        for i in 0..<sparse.count {
+            #expect(sparse[i] == dense[i, 0])
+        }
+    }
+}
+
+struct CSRMatrixSparseDenseMatmulTests {
+    @Test func basic() {
+        // A: [[1, 0], [0, 2]]  B: [[3, 4], [5, 6]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let b = Tensor([[3, 4], [5, 6]])
+        // row 0: 1*[3,4] = [3, 4]
+        // row 1: 2*[5,6] = [10, 12]
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.shape == [2, 2])
+        #expect(Array(result) == [3, 4, 10, 12])
+    }
+
+    @Test func identityMatrix() {
+        let eye = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 1]
+        )
+        let b = Tensor([[10, 20, 30], [40, 50, 60]])
+        let result = CSRMatrix.matmul(eye, b)
+        #expect(Array(result) == Array(b))
+    }
+
+    @Test func emptyMatrix() {
+        let a = CSRMatrix<Int>(rows: 2, columns: 3)
+        let b = Tensor([[1, 2], [3, 4], [5, 6]])
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.shape == [2, 2])
+        #expect(Array(result) == [0, 0, 0, 0])
+    }
+
+    @Test func emptyRows() {
+        // Row 1 is empty
+        let a = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 1, 2],
+            columnIndices: [0, 1],
+            values: [2, 3]
+        )
+        let b = Tensor([[1, 0], [0, 1]])
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.shape == [3, 2])
+        #expect(Array(result) == [2, 0, 0, 0, 0, 3])
+    }
+
+    @Test func matchesDense() {
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 4],
+            columnIndices: [0, 2, 1, 2],
+            values: [1, 2, 3, 4]
+        )
+        let b = Tensor([[1, 2], [3, 4], [5, 6]])
+        let sparse = CSRMatrix.matmul(a, b)
+        let dense = Tensor.matmul(a.toTensor(), b)
+        #expect(Array(sparse) == Array(dense))
+    }
+
+    @Test func nonSquare() {
+        // A: 2x3, B: 3x4 -> 2x4
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 1, 2],
+            columnIndices: [1, 0],
+            values: [5, 3]
+        )
+        let b = Tensor(shape: [3, 4], elements: Array(1...12))
+        let sparse = CSRMatrix.matmul(a, b)
+        let dense = Tensor.matmul(a.toTensor(), b)
+        #expect(sparse.shape == [2, 4])
+        #expect(Array(sparse) == Array(dense))
+    }
+}
+
+struct CSRMatrixSparseMatmulTests {
+    @Test func basic() {
+        // A: [[1, 0], [0, 2]]  B: [[3, 0], [0, 4]]
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 2]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [3, 4]
+        )
+        // row 0: 1*[3,0] = [3, 0]
+        // row 1: 2*[0,4] = [0, 8]
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.rows == 2)
+        #expect(result.columns == 2)
+        #expect(result.rowPointers == [0, 1, 2])
+        #expect(result.columnIndices == [0, 1])
+        #expect(result.values == [3, 8])
+    }
+
+    @Test func identityMatrix() {
+        let eye = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 1],
+            values: [1, 1]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 2, 2],
+            columnIndices: [0, 1],
+            values: [10, 20]
+        )
+        let result = CSRMatrix.matmul(eye, b)
+        #expect(result == b)
+    }
+
+    @Test func emptyOperand() {
+        let a = CSRMatrix<Int>(rows: 2, columns: 3)
+        let b = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [1, 2, 3]
+        )
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.rows == 2)
+        #expect(result.columns == 2)
+        #expect(result.nnz == 0)
+    }
+
+    @Test func disjointStructure() {
+        // A has columns 0; B has nonzeros in row 1 only
+        // No overlap: A's column indices don't match B's nonzero rows
+        let a = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 1, 1],
+            columnIndices: [0],
+            values: [5]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 2,
+            rowPointers: [0, 0, 1],
+            columnIndices: [1],
+            values: [3]
+        )
+        let result = CSRMatrix.matmul(a, b)
+        #expect(result.nnz == 0)
+    }
+
+    @Test func matchesDense() {
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 2, 3],
+            columnIndices: [0, 2, 1],
+            values: [1, 2, 3]
+        )
+        let b = CSRMatrix(
+            rows: 3, columns: 2,
+            rowPointers: [0, 1, 2, 3],
+            columnIndices: [0, 1, 0],
+            values: [4, 5, 6]
+        )
+        let sparse = CSRMatrix.matmul(a, b)
+        let dense = Tensor.matmul(a.toTensor(), b.toTensor())
+        #expect(Array(sparse.toTensor()) == Array(dense))
+    }
+
+    @Test func cancellation() {
+        // Products cancel out to zero for some entries
+        // A: [[1, -1]], B: [[3], [3]]  ->  1*3 + (-1)*3 = 0
+        let a = CSRMatrix(
+            rows: 1, columns: 2,
+            rowPointers: [0, 2],
+            columnIndices: [0, 1],
+            values: [1, -1]
+        )
+        let b = CSRMatrix(
+            rows: 2, columns: 1,
+            rowPointers: [0, 1, 2],
+            columnIndices: [0, 0],
+            values: [3, 3]
+        )
+        let result = CSRMatrix.matmul(a, b)
+        // Explicit zeros are kept (consistent with sparse arithmetic)
+        #expect(result.toTensor()[0, 0] == 0)
+    }
+
+    @Test func nonSquare() {
+        // A: 2x3, B: 3x4
+        let a = CSRMatrix(
+            rows: 2, columns: 3,
+            rowPointers: [0, 1, 2],
+            columnIndices: [1, 0],
+            values: [5, 3]
+        )
+        let b = CSRMatrix(
+            rows: 3, columns: 4,
+            rowPointers: [0, 2, 3, 4],
+            columnIndices: [0, 3, 1, 2],
+            values: [1, 2, 3, 4]
+        )
+        let sparse = CSRMatrix.matmul(a, b)
+        let dense = Tensor.matmul(a.toTensor(), b.toTensor())
+        #expect(sparse.rows == 2)
+        #expect(sparse.columns == 4)
+        #expect(Array(sparse.toTensor()) == Array(dense))
+    }
+}


### PR DESCRIPTION
## Summary

- `CSRMatrix.matvec(_:_:)` -- SpMV: CSR [m,n] * dense vector [n] -> dense [m]
- `CSRMatrix.matmul(_:_:)` -- SpMM: CSR [m,k] * dense Tensor [k,n] -> Tensor [m,n]
- `CSRMatrix.matmul(_:_:)` -- SpGEMM: CSR [m,k] * CSR [k,n] -> CSR [m,n]

SpGEMM uses a row-wise dense accumulator with boolean marker array. Explicit zeros from cancellation are kept, consistent with existing sparse arithmetic.

Closes #39

## Test plan

- [x] SpMV: basic, identity, empty, empty rows, single row, matches dense
- [x] SpMM (sparse*dense): basic, identity, empty, empty rows, matches dense, non-square
- [x] SpGEMM (sparse*sparse): basic, identity, empty, disjoint structure, matches dense, cancellation, non-square