### PR TITLE
Fix three codebase inconsistencies

### DIFF
--- a/Sources/SwiftMatrix/COOTensor.swift
+++ b/Sources/SwiftMatrix/COOTensor.swift
@@ -69,7 +69,6 @@ public struct COOTensor<Element> {
         }
 
         // Sort entries by row-major lexicographic order
-        let strides = Tensor<Element>.computeStrides(for: shape)
         var entryOrder = Array(0..<nnz)
         entryOrder.sort { a, b in
             for axis in 0..<shape.count {

--- a/Sources/SwiftMatrix/Tensor+Accelerate.swift
+++ b/Sources/SwiftMatrix/Tensor+Accelerate.swift
@@ -323,15 +323,15 @@ extension Tensor where Element: AccelerateFloatingPoint {
             // Sum across rows -> shape [cols]
             var result = [Element](repeating: .zero, count: cols)
             elements.withUnsafeBufferPointer { buf in
-                for i in 0..<rows {
-                    let rowBuf = UnsafeBufferPointer(
-                        start: buf.baseAddress! + i * cols,
-                        count: cols
-                    )
-                    result.withUnsafeMutableBufferPointer { resBuf in
-                        for j in 0..<cols {
-                            resBuf[j] += rowBuf[j]
-                        }
+                result.withUnsafeMutableBufferPointer { resBuf in
+                    for i in 0..<rows {
+                        let rowBuf = UnsafeBufferPointer(
+                            start: buf.baseAddress! + i * cols,
+                            count: cols
+                        )
+                        Element._vDSPAdd(
+                            UnsafeBufferPointer(resBuf), rowBuf,
+                            result: resBuf)
                     }
                 }
             }

--- a/Sources/SwiftMatrix/Tensor+Reductions.swift
+++ b/Sources/SwiftMatrix/Tensor+Reductions.swift
@@ -1,7 +1,7 @@
 /// Reductions and linear algebra operations for ``Tensor``.
 
 extension Tensor where Element: Numeric {
-    /// Computes the dot product (inner product) of two rank-1 tensors.
+    /// Computes the dot product (inner product) of two rank-1 tensors. O(n).
     ///
     /// ```swift
     /// let a = Tensor(shape: [3], elements: [1, 2, 3])
@@ -19,7 +19,7 @@ extension Tensor where Element: Numeric {
         return zip(lhs, rhs).reduce(.zero) { $0 + $1.0 * $1.1 }
     }
 
-    /// Multiplies two rank-2 tensors (matrix multiplication).
+    /// Multiplies two rank-2 tensors (matrix multiplication). O(m * n * k).
     ///
     /// ```swift
     /// let a = Tensor([[1, 2], [3, 4]])       // 2x2
@@ -55,7 +55,7 @@ extension Tensor where Element: Numeric {
 // MARK: - Sum
 
 extension Tensor where Element: AdditiveArithmetic {
-    /// Returns the sum of all elements.
+    /// Returns the sum of all elements. O(count).
     ///
     /// ```swift
     /// Tensor([[1, 2, 3], [4, 5, 6]]).sum()  // 21
@@ -64,7 +64,7 @@ extension Tensor where Element: AdditiveArithmetic {
         reduce(.zero, +)
     }
 
-    /// Returns a tensor with one axis collapsed by summation.
+    /// Returns a tensor with one axis collapsed by summation. O(count).
     ///
     /// The result has rank reduced by 1. For a tensor with shape `[2, 3]`:
     /// - `sum(axis: 0)` produces shape `[3]` (sum across rows)
@@ -118,7 +118,9 @@ extension Tensor where Element: AdditiveArithmetic {
 // MARK: - Mean
 
 extension Tensor where Element: FloatingPoint {
-    /// Returns the arithmetic mean of all elements.
+    /// Returns the arithmetic mean of all elements. O(count).
+    ///
+    /// The divisor is ``count`` (the total number of elements).
     ///
     /// ```swift
     /// Tensor(shape: [4], elements: [1.0, 2.0, 3.0, 4.0]).mean()  // 2.5
@@ -127,7 +129,9 @@ extension Tensor where Element: FloatingPoint {
         sum() / Element(count)
     }
 
-    /// Returns a tensor with one axis collapsed by averaging.
+    /// Returns a tensor with one axis collapsed by averaging. O(count).
+    ///
+    /// The divisor is the size of the collapsed axis (`shape[axis]`).
     ///
     /// The result has rank reduced by 1. For a tensor with shape `[2, 3]`:
     /// - `mean(axis: 0)` produces shape `[3]` (mean across rows)


### PR DESCRIPTION
## Summary

- Vectorize Accelerate axis-0 `sum(axis:)` with `_vDSPAdd` instead of scalar loop, and hoist `withUnsafeMutableBufferPointer` outside the row loop
- Remove dead `strides` variable in `COOTensor.init` (eliminates compiler warning)
- Add O() complexity and divisor notes to dense `Tensor` reduction doc comments to match sparse reduction doc style

Closes #43

## Test plan

- [x] `swift build` passes with no warnings (strides warning eliminated)
- [x] `swift test` passes (287 tests, no behavioral changes)