### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: swift-actions/setup-swift@v2
         with:
           swift-version: "6.2"
+      - uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Build
         run: swift build
       - name: Test


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` to run `swift build` and `swift test` on push to `main` and PRs targeting `main`
- Uses `macos-15` runner (required for Accelerate/vDSP code paths)
- Pins Swift 6.2 via `swift-actions/setup-swift@v2`

Closes #45

## Test plan
- [x] CI workflow triggers on this PR
- [x] `swift build` step passes
- [x] `swift test` step passes